### PR TITLE
CNNMC-6 Compare the distribution of two equal layers between two CNNs

### DIFF
--- a/cnn_comparison.py
+++ b/cnn_comparison.py
@@ -1,14 +1,14 @@
 import ai_model_creator
 import data_manipulator
+import comparison_tools
 from keras.datasets import mnist
-
-normal_model = ai_model_creator.cnn_model()
-bad_model = ai_model_creator.cnn_model()
 
 # import data
 (train_images, train_labels), (test_images, test_labels) = mnist.load_data()
 
 ## Unbalanced model
+bad_model = ai_model_creator.cnn_model()
+
 # split the train images and labels to unbalanced sub-sets
 train_half_set_iter = data_manipulator.split_unbalanced(train_labels, [i for i in range(0, 5)],
                                                         [i for i in range(5, 10)], 100)
@@ -31,6 +31,8 @@ test_loss, test_acc_unbalanced = bad_model.evaluate(test_images, test_labels)
 print(test_acc_unbalanced)
 
 ## Normal model
+normal_model = ai_model_creator.cnn_model()
+
 # prepare data
 train_images, train_labels = data_manipulator.prepare_visual_data(train_images, train_labels)
 
@@ -42,3 +44,31 @@ test_loss, test_acc_normal = normal_model.evaluate(test_images, test_labels)
 print("Accuracy")
 print("Normal model", test_acc_normal)
 print("Unbalanced model", test_acc_unbalanced)
+
+nm_dense_layer = comparison_tools.find_layer(normal_model, 'dense')
+_, nm_dense_weights, nm_dense_biases = comparison_tools.get_weights_for_layer(nm_dense_layer)
+
+bm_dense_layer = comparison_tools.find_layer(bad_model, 'dense')
+_, bm_dense_weights, bm_dense_biases = comparison_tools.get_weights_for_layer(bm_dense_layer)
+
+print('Comparison between weights:')
+print('K-S comparison (the distribution is similar when the K-S statistic is small and p > 0.05):')
+weights_ks = comparison_tools.compare_distributions_with_ks(nm_dense_weights, bm_dense_weights)
+print('K-S=%.6s p=%.5s' % weights_ks)
+
+print('Histogram comparison')
+nm_weights_hist, bm_weights_hist, weights_bins = comparison_tools.compare_distributions_with_histogram(nm_dense_weights,
+                                                                                                       bm_dense_weights)
+print('normal: %s\n   bad: %s' % (nm_weights_hist, bm_weights_hist))
+print('bins  : %s\n' % weights_bins)
+
+print('Comparison between biases:')
+print('K-S comparison (the distribution is similar when the K-S statistic is small and p > 0.05):')
+biases_ks = comparison_tools.compare_distributions_with_ks(nm_dense_biases, bm_dense_biases)
+print('K-S=%.6s p=%.5s' % biases_ks)
+
+print('Histogram comparison')
+nm_biases_hist, bm_biases_hist, biases_bins = comparison_tools.compare_distributions_with_histogram(nm_dense_biases,
+                                                                                                    bm_dense_biases)
+print('normal: %s\n   bad: %s' % (nm_biases_hist, bm_biases_hist))
+print('bins  : %s\n' % bm_biases_hist)

--- a/comparison_tools.py
+++ b/comparison_tools.py
@@ -1,0 +1,40 @@
+from scipy.stats import ks_2samp
+import numpy as np
+
+'''
+Find the Nth layer of the specified type.
+args:
+- model : the model that will be searched
+- type  : the lowercase type, as it is automatically saved by keras in the layer's name (e.g. conv2d, dense)
+- order : 0 by default (the first matching layer will be returned)
+'''
+
+
+def find_layer(model, type, order=0):
+    num_found = 0
+    for layer in model.layers:
+        if type + '_' in layer.get_config()['name']:
+            if order == num_found:
+                return layer
+
+            num_found += 1
+    return None
+
+
+def get_weights_for_layer(layer):
+    layer_weights = layer.get_weights()[0]
+    layer_weights_flat = layer_weights.reshape(layer_weights.size)
+    layer_bias = layer.get_weights()[1]
+
+    return layer_weights, layer_weights_flat, layer_bias
+
+
+def compare_distributions_with_ks(vectorA, vectorB):
+    ks = ks_2samp(vectorA, vectorB)
+    return ks
+
+
+def compare_distributions_with_histogram(vectorA, vectorB):
+    hist_a, bins = np.histogram(vectorA)
+    hist_b, _ = np.histogram(vectorB, bins)
+    return hist_a, hist_b, bins


### PR DESCRIPTION
```
/usr/bin/python3.6 /snap/pycharm-community/179/plugins/python-ce/helpers/pydev/pydevconsole.py --mode=client --port=41169
import sys; print('Python %s on %s' % (sys.version, sys.platform))
sys.path.extend(['/home/athena/PycharmProjects/AI-model-comparison'])
Python 3.6.9 (default, Nov  7 2019, 10:44:02) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.3.0 -- An enhanced Interactive Python. Type '?' for help.
PyDev console: using IPython 7.3.0
Python 3.6.9 (default, Nov  7 2019, 10:44:02) 
[GCC 8.3.0] on linux
runfile('/home/athena/PycharmProjects/AI-model-comparison/cnn_comparison.py', wdir='/home/athena/PycharmProjects/AI-model-comparison')
Using TensorFlow backend.
WARNING:tensorflow:From /home/athena/.local/lib/python3.6/site-packages/tensorflow/python/framework/op_def_library.py:263: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.
Instructions for updating:
Colocations handled automatically by placer.
WARNING:tensorflow:From /home/athena/.local/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.
Instructions for updating:
Use tf.cast instead.
Epoch 1/5
2020-02-22 13:54:45.723210: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2020-02-22 13:54:45.788861: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:998] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2020-02-22 13:54:45.789315: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x29bb370 executing computations on platform CUDA. Devices:
2020-02-22 13:54:45.789386: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): GeForce GTX 1060 3GB, Compute Capability 6.1
2020-02-22 13:54:45.809514: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 3399555000 Hz
2020-02-22 13:54:45.810377: I tensorflow/compiler/xla/service/service.cc:150] XLA service 0x2a2ee10 executing computations on platform Host. Devices:
2020-02-22 13:54:45.810409: I tensorflow/compiler/xla/service/service.cc:158]   StreamExecutor device (0): <undefined>, <undefined>
2020-02-22 13:54:45.810614: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1433] Found device 0 with properties: 
name: GeForce GTX 1060 3GB major: 6 minor: 1 memoryClockRate(GHz): 1.7085
pciBusID: 0000:1d:00.0
totalMemory: 2.95GiB freeMemory: 2.56GiB
2020-02-22 13:54:45.810642: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1512] Adding visible gpu devices: 0
2020-02-22 13:54:45.811614: I tensorflow/core/common_runtime/gpu/gpu_device.cc:984] Device interconnect StreamExecutor with strength 1 edge matrix:
2020-02-22 13:54:45.811637: I tensorflow/core/common_runtime/gpu/gpu_device.cc:990]      0 
2020-02-22 13:54:45.811648: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1003] 0:   N 
2020-02-22 13:54:45.811750: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1115] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 2319 MB memory) -> physical GPU (device: 0, name: GeForce GTX 1060 3GB, pci bus id: 0000:1d:00.0, compute capability: 6.1)
2020-02-22 13:54:46.371272: I tensorflow/stream_executor/dso_loader.cc:152] successfully opened CUDA library libcublas.so.10.0 locally
   64/30596 [..............................] - ETA: 11:31 - loss: 2.3207 - acc: 0.0938
  704/30596 [..............................] - ETA: 1:03 - loss: 1.4633 - acc: 0.5170 
 1344/30596 [>.............................] - ETA: 33s - loss: 1.0121 - acc: 0.6853 
 1984/30596 [>.............................] - ETA: 23s - loss: 0.7942 - acc: 0.7571
 2624/30596 [=>............................] - ETA: 17s - loss: 0.6583 - acc: 0.8018
 3200/30596 [==>...........................] - ETA: 14s - loss: 0.5963 - acc: 0.8241
 3840/30596 [==>...........................] - ETA: 12s - loss: 0.5421 - acc: 0.8409
 4480/30596 [===>..........................] - ETA: 10s - loss: 0.4905 - acc: 0.8565
 5184/30596 [====>.........................] - ETA: 9s - loss: 0.4538 - acc: 0.8682 
 5824/30596 [====>.........................] - ETA: 8s - loss: 0.4217 - acc: 0.8774
 6464/30596 [=====>........................] - ETA: 7s - loss: 0.3932 - acc: 0.8855
 7104/30596 [=====>........................] - ETA: 6s - loss: 0.3756 - acc: 0.8918
 7744/30596 [======>.......................] - ETA: 6s - loss: 0.3574 - acc: 0.8970
 8448/30596 [=======>......................] - ETA: 5s - loss: 0.3427 - acc: 0.9015
 9088/30596 [=======>......................] - ETA: 5s - loss: 0.3281 - acc: 0.9057
 9792/30596 [========>.....................] - ETA: 4s - loss: 0.3126 - acc: 0.9102
10432/30596 [=========>....................] - ETA: 4s - loss: 0.3010 - acc: 0.9133
11136/30596 [=========>....................] - ETA: 4s - loss: 0.2880 - acc: 0.9175
11776/30596 [==========>...................] - ETA: 3s - loss: 0.2809 - acc: 0.9192
12416/30596 [===========>..................] - ETA: 3s - loss: 0.2734 - acc: 0.9210
13056/30596 [===========>..................] - ETA: 3s - loss: 0.2655 - acc: 0.9229
13696/30596 [============>.................] - ETA: 3s - loss: 0.2562 - acc: 0.9253
14400/30596 [=============>................] - ETA: 2s - loss: 0.2490 - acc: 0.9275
15040/30596 [=============>................] - ETA: 2s - loss: 0.2437 - acc: 0.9288
15680/30596 [==============>...............] - ETA: 2s - loss: 0.2376 - acc: 0.9307
16320/30596 [===============>..............] - ETA: 2s - loss: 0.2320 - acc: 0.9325
16960/30596 [===============>..............] - ETA: 2s - loss: 0.2275 - acc: 0.9337
17600/30596 [================>.............] - ETA: 2s - loss: 0.2229 - acc: 0.9351
18240/30596 [================>.............] - ETA: 1s - loss: 0.2179 - acc: 0.9367
18880/30596 [=================>............] - ETA: 1s - loss: 0.2120 - acc: 0.9383
19520/30596 [==================>...........] - ETA: 1s - loss: 0.2080 - acc: 0.9397
20160/30596 [==================>...........] - ETA: 1s - loss: 0.2036 - acc: 0.9409
20800/30596 [===================>..........] - ETA: 1s - loss: 0.1984 - acc: 0.9424
21440/30596 [====================>.........] - ETA: 1s - loss: 0.1953 - acc: 0.9432
22080/30596 [====================>.........] - ETA: 1s - loss: 0.1914 - acc: 0.9442
22720/30596 [=====================>........] - ETA: 1s - loss: 0.1878 - acc: 0.9452
23360/30596 [=====================>........] - ETA: 1s - loss: 0.1848 - acc: 0.9463
24000/30596 [======================>.......] - ETA: 0s - loss: 0.1814 - acc: 0.9473
24704/30596 [=======================>......] - ETA: 0s - loss: 0.1777 - acc: 0.9485
25344/30596 [=======================>......] - ETA: 0s - loss: 0.1749 - acc: 0.9493
25984/30596 [========================>.....] - ETA: 0s - loss: 0.1719 - acc: 0.9502
26624/30596 [=========================>....] - ETA: 0s - loss: 0.1698 - acc: 0.9508
27264/30596 [=========================>....] - ETA: 0s - loss: 0.1666 - acc: 0.9518
27904/30596 [==========================>...] - ETA: 0s - loss: 0.1640 - acc: 0.9525
28544/30596 [==========================>...] - ETA: 0s - loss: 0.1611 - acc: 0.9533
29184/30596 [===========================>..] - ETA: 0s - loss: 0.1592 - acc: 0.9540
29824/30596 [============================>.] - ETA: 0s - loss: 0.1569 - acc: 0.9546
30400/30596 [============================>.] - ETA: 0s - loss: 0.1546 - acc: 0.9552
30596/30596 [==============================] - 4s 129us/step - loss: 0.1540 - acc: 0.9553
Epoch 2/5
   64/30596 [..............................] - ETA: 3s - loss: 0.0709 - acc: 0.9688
  704/30596 [..............................] - ETA: 2s - loss: 0.0575 - acc: 0.9886
 1280/30596 [>.............................] - ETA: 2s - loss: 0.0480 - acc: 0.9883
 1984/30596 [>.............................] - ETA: 2s - loss: 0.0426 - acc: 0.9884
 2688/30596 [=>............................] - ETA: 2s - loss: 0.0568 - acc: 0.9866
 3328/30596 [==>...........................] - ETA: 2s - loss: 0.0546 - acc: 0.9868
 3904/30596 [==>...........................] - ETA: 2s - loss: 0.0538 - acc: 0.9859
 4544/30596 [===>..........................] - ETA: 2s - loss: 0.0508 - acc: 0.9870
 5184/30596 [====>.........................] - ETA: 2s - loss: 0.0486 - acc: 0.9875
 5824/30596 [====>.........................] - ETA: 2s - loss: 0.0477 - acc: 0.9875
 6400/30596 [=====>........................] - ETA: 2s - loss: 0.0472 - acc: 0.9878
 7040/30596 [=====>........................] - ETA: 1s - loss: 0.0453 - acc: 0.9884
 7680/30596 [======>.......................] - ETA: 1s - loss: 0.0480 - acc: 0.9875
 8320/30596 [=======>......................] - ETA: 1s - loss: 0.0466 - acc: 0.9879
 9024/30596 [=======>......................] - ETA: 1s - loss: 0.0440 - acc: 0.9884
 9664/30596 [========>.....................] - ETA: 1s - loss: 0.0438 - acc: 0.9884
10304/30596 [=========>....................] - ETA: 1s - loss: 0.0430 - acc: 0.9885
10944/30596 [=========>....................] - ETA: 1s - loss: 0.0413 - acc: 0.9890
11584/30596 [==========>...................] - ETA: 1s - loss: 0.0409 - acc: 0.9891
12288/30596 [===========>..................] - ETA: 1s - loss: 0.0409 - acc: 0.9889
12928/30596 [===========>..................] - ETA: 1s - loss: 0.0410 - acc: 0.9889
13568/30596 [============>.................] - ETA: 1s - loss: 0.0407 - acc: 0.9890
14208/30596 [============>.................] - ETA: 1s - loss: 0.0401 - acc: 0.9891
14848/30596 [=============>................] - ETA: 1s - loss: 0.0403 - acc: 0.9892
15488/30596 [==============>...............] - ETA: 1s - loss: 0.0408 - acc: 0.9892
16128/30596 [==============>...............] - ETA: 1s - loss: 0.0411 - acc: 0.9891
16768/30596 [===============>..............] - ETA: 1s - loss: 0.0412 - acc: 0.9892
17408/30596 [================>.............] - ETA: 1s - loss: 0.0413 - acc: 0.9892
18048/30596 [================>.............] - ETA: 1s - loss: 0.0427 - acc: 0.9890
18688/30596 [=================>............] - ETA: 0s - loss: 0.0422 - acc: 0.9890
19328/30596 [=================>............] - ETA: 0s - loss: 0.0420 - acc: 0.9891
19968/30596 [==================>...........] - ETA: 0s - loss: 0.0420 - acc: 0.9890
20608/30596 [===================>..........] - ETA: 0s - loss: 0.0416 - acc: 0.9891
21248/30596 [===================>..........] - ETA: 0s - loss: 0.0418 - acc: 0.9890
21952/30596 [====================>.........] - ETA: 0s - loss: 0.0420 - acc: 0.9889
22656/30596 [=====================>........] - ETA: 0s - loss: 0.0416 - acc: 0.9889
23360/30596 [=====================>........] - ETA: 0s - loss: 0.0416 - acc: 0.9887
24064/30596 [======================>.......] - ETA: 0s - loss: 0.0420 - acc: 0.9886
24640/30596 [=======================>......] - ETA: 0s - loss: 0.0420 - acc: 0.9886
25280/30596 [=======================>......] - ETA: 0s - loss: 0.0413 - acc: 0.9888
25984/30596 [========================>.....] - ETA: 0s - loss: 0.0406 - acc: 0.9889
26560/30596 [=========================>....] - ETA: 0s - loss: 0.0400 - acc: 0.9891
27200/30596 [=========================>....] - ETA: 0s - loss: 0.0399 - acc: 0.9890
27840/30596 [==========================>...] - ETA: 0s - loss: 0.0397 - acc: 0.9890
28544/30596 [==========================>...] - ETA: 0s - loss: 0.0392 - acc: 0.9891
29184/30596 [===========================>..] - ETA: 0s - loss: 0.0390 - acc: 0.9891
29824/30596 [============================>.] - ETA: 0s - loss: 0.0391 - acc: 0.9891
30528/30596 [============================>.] - ETA: 0s - loss: 0.0392 - acc: 0.9890
30596/30596 [==============================] - 2s 82us/step - loss: 0.0393 - acc: 0.9890
Epoch 3/5
   64/30596 [..............................] - ETA: 3s - loss: 0.0012 - acc: 1.0000
  704/30596 [..............................] - ETA: 2s - loss: 0.0142 - acc: 0.9943
 1280/30596 [>.............................] - ETA: 2s - loss: 0.0160 - acc: 0.9930
 1856/30596 [>.............................] - ETA: 2s - loss: 0.0134 - acc: 0.9952
 2496/30596 [=>............................] - ETA: 2s - loss: 0.0177 - acc: 0.9936
 3200/30596 [==>...........................] - ETA: 2s - loss: 0.0181 - acc: 0.9934
 3840/30596 [==>...........................] - ETA: 2s - loss: 0.0196 - acc: 0.9924
 4480/30596 [===>..........................] - ETA: 2s - loss: 0.0224 - acc: 0.9922
 5120/30596 [====>.........................] - ETA: 2s - loss: 0.0235 - acc: 0.9920
 5760/30596 [====>.........................] - ETA: 2s - loss: 0.0232 - acc: 0.9920
 6400/30596 [=====>........................] - ETA: 2s - loss: 0.0231 - acc: 0.9920
 7040/30596 [=====>........................] - ETA: 1s - loss: 0.0271 - acc: 0.9916
 7616/30596 [======>.......................] - ETA: 1s - loss: 0.0269 - acc: 0.9917
 8256/30596 [=======>......................] - ETA: 1s - loss: 0.0254 - acc: 0.9922
 8896/30596 [=======>......................] - ETA: 1s - loss: 0.0267 - acc: 0.9922
 9536/30596 [========>.....................] - ETA: 1s - loss: 0.0273 - acc: 0.9919
10176/30596 [========>.....................] - ETA: 1s - loss: 0.0283 - acc: 0.9914
10816/30596 [=========>....................] - ETA: 1s - loss: 0.0289 - acc: 0.9915
11456/30596 [==========>...................] - ETA: 1s - loss: 0.0283 - acc: 0.9915
12096/30596 [==========>...................] - ETA: 1s - loss: 0.0275 - acc: 0.9916
12736/30596 [===========>..................] - ETA: 1s - loss: 0.0270 - acc: 0.9917
13376/30596 [============>.................] - ETA: 1s - loss: 0.0268 - acc: 0.9916
14016/30596 [============>.................] - ETA: 1s - loss: 0.0262 - acc: 0.9918
14720/30596 [=============>................] - ETA: 1s - loss: 0.0257 - acc: 0.9920
15360/30596 [==============>...............] - ETA: 1s - loss: 0.0264 - acc: 0.9919
16000/30596 [==============>...............] - ETA: 1s - loss: 0.0257 - acc: 0.9921
16704/30596 [===============>..............] - ETA: 1s - loss: 0.0268 - acc: 0.9919
17344/30596 [================>.............] - ETA: 1s - loss: 0.0267 - acc: 0.9918
17984/30596 [================>.............] - ETA: 1s - loss: 0.0266 - acc: 0.9918
18624/30596 [=================>............] - ETA: 0s - loss: 0.0266 - acc: 0.9917
19264/30596 [=================>............] - ETA: 0s - loss: 0.0267 - acc: 0.9917
19904/30596 [==================>...........] - ETA: 0s - loss: 0.0272 - acc: 0.9915
20544/30596 [===================>..........] - ETA: 0s - loss: 0.0269 - acc: 0.9916
21184/30596 [===================>..........] - ETA: 0s - loss: 0.0265 - acc: 0.9918
21760/30596 [====================>.........] - ETA: 0s - loss: 0.0263 - acc: 0.9919
22400/30596 [====================>.........] - ETA: 0s - loss: 0.0264 - acc: 0.9919
23040/30596 [=====================>........] - ETA: 0s - loss: 0.0260 - acc: 0.9920
23680/30596 [======================>.......] - ETA: 0s - loss: 0.0259 - acc: 0.9920
24320/30596 [======================>.......] - ETA: 0s - loss: 0.0269 - acc: 0.9919
24960/30596 [=======================>......] - ETA: 0s - loss: 0.0266 - acc: 0.9921
25600/30596 [========================>.....] - ETA: 0s - loss: 0.0262 - acc: 0.9922
26304/30596 [========================>.....] - ETA: 0s - loss: 0.0258 - acc: 0.9923
26944/30596 [=========================>....] - ETA: 0s - loss: 0.0255 - acc: 0.9923
27584/30596 [==========================>...] - ETA: 0s - loss: 0.0256 - acc: 0.9923
28224/30596 [==========================>...] - ETA: 0s - loss: 0.0254 - acc: 0.9925
28864/30596 [===========================>..] - ETA: 0s - loss: 0.0251 - acc: 0.9925
29504/30596 [===========================>..] - ETA: 0s - loss: 0.0251 - acc: 0.9924
30144/30596 [============================>.] - ETA: 0s - loss: 0.0251 - acc: 0.9925
30596/30596 [==============================] - 3s 82us/step - loss: 0.0250 - acc: 0.9926
Epoch 4/5
   64/30596 [..............................] - ETA: 2s - loss: 0.0025 - acc: 1.0000
  768/30596 [..............................] - ETA: 2s - loss: 0.0047 - acc: 1.0000
 1408/30596 [>.............................] - ETA: 2s - loss: 0.0069 - acc: 0.9979
 1984/30596 [>.............................] - ETA: 2s - loss: 0.0084 - acc: 0.9970
 2624/30596 [=>............................] - ETA: 2s - loss: 0.0140 - acc: 0.9947
 3200/30596 [==>...........................] - ETA: 2s - loss: 0.0125 - acc: 0.9953
 3840/30596 [==>...........................] - ETA: 2s - loss: 0.0170 - acc: 0.9948
 4480/30596 [===>..........................] - ETA: 2s - loss: 0.0152 - acc: 0.9953
 5120/30596 [====>.........................] - ETA: 2s - loss: 0.0137 - acc: 0.9959
 5760/30596 [====>.........................] - ETA: 2s - loss: 0.0129 - acc: 0.9960
 6336/30596 [=====>........................] - ETA: 2s - loss: 0.0145 - acc: 0.9961
 7040/30596 [=====>........................] - ETA: 1s - loss: 0.0146 - acc: 0.9960
 7680/30596 [======>.......................] - ETA: 1s - loss: 0.0139 - acc: 0.9962
 8384/30596 [=======>......................] - ETA: 1s - loss: 0.0146 - acc: 0.9961
 9088/30596 [=======>......................] - ETA: 1s - loss: 0.0141 - acc: 0.9960
 9728/30596 [========>.....................] - ETA: 1s - loss: 0.0149 - acc: 0.9957
10368/30596 [=========>....................] - ETA: 1s - loss: 0.0145 - acc: 0.9958
11008/30596 [=========>....................] - ETA: 1s - loss: 0.0147 - acc: 0.9954
11648/30596 [==========>...................] - ETA: 1s - loss: 0.0154 - acc: 0.9953
12288/30596 [===========>..................] - ETA: 1s - loss: 0.0160 - acc: 0.9953
12928/30596 [===========>..................] - ETA: 1s - loss: 0.0167 - acc: 0.9952
13632/30596 [============>.................] - ETA: 1s - loss: 0.0173 - acc: 0.9952
14336/30596 [=============>................] - ETA: 1s - loss: 0.0167 - acc: 0.9953
15040/30596 [=============>................] - ETA: 1s - loss: 0.0173 - acc: 0.9951
15744/30596 [==============>...............] - ETA: 1s - loss: 0.0173 - acc: 0.9949
16384/30596 [===============>..............] - ETA: 1s - loss: 0.0171 - acc: 0.9949
17024/30596 [===============>..............] - ETA: 1s - loss: 0.0167 - acc: 0.9951
17664/30596 [================>.............] - ETA: 1s - loss: 0.0167 - acc: 0.9951
18304/30596 [================>.............] - ETA: 0s - loss: 0.0170 - acc: 0.9951
19008/30596 [=================>............] - ETA: 0s - loss: 0.0172 - acc: 0.9951
19584/30596 [==================>...........] - ETA: 0s - loss: 0.0168 - acc: 0.9952
20224/30596 [==================>...........] - ETA: 0s - loss: 0.0170 - acc: 0.9952
20864/30596 [===================>..........] - ETA: 0s - loss: 0.0170 - acc: 0.9952
21568/30596 [====================>.........] - ETA: 0s - loss: 0.0168 - acc: 0.9952
22208/30596 [====================>.........] - ETA: 0s - loss: 0.0164 - acc: 0.9953
22784/30596 [=====================>........] - ETA: 0s - loss: 0.0166 - acc: 0.9953
23424/30596 [=====================>........] - ETA: 0s - loss: 0.0164 - acc: 0.9953
24064/30596 [======================>.......] - ETA: 0s - loss: 0.0171 - acc: 0.9952
24704/30596 [=======================>......] - ETA: 0s - loss: 0.0169 - acc: 0.9952
25344/30596 [=======================>......] - ETA: 0s - loss: 0.0170 - acc: 0.9951
25984/30596 [========================>.....] - ETA: 0s - loss: 0.0172 - acc: 0.9952
26624/30596 [=========================>....] - ETA: 0s - loss: 0.0172 - acc: 0.9951
27264/30596 [=========================>....] - ETA: 0s - loss: 0.0170 - acc: 0.9952
27968/30596 [==========================>...] - ETA: 0s - loss: 0.0170 - acc: 0.9951
28736/30596 [===========================>..] - ETA: 0s - loss: 0.0173 - acc: 0.9952
29376/30596 [===========================>..] - ETA: 0s - loss: 0.0170 - acc: 0.9953
30016/30596 [============================>.] - ETA: 0s - loss: 0.0170 - acc: 0.9953
30596/30596 [==============================] - 2s 81us/step - loss: 0.0171 - acc: 0.9953
Epoch 5/5
   64/30596 [..............................] - ETA: 3s - loss: 1.5627e-04 - acc: 1.0000
  704/30596 [..............................] - ETA: 2s - loss: 0.0107 - acc: 0.9957    
 1344/30596 [>.............................] - ETA: 2s - loss: 0.0098 - acc: 0.9963
 1984/30596 [>.............................] - ETA: 2s - loss: 0.0108 - acc: 0.9960
 2624/30596 [=>............................] - ETA: 2s - loss: 0.0134 - acc: 0.9954
 3264/30596 [==>...........................] - ETA: 2s - loss: 0.0117 - acc: 0.9963
 3904/30596 [==>...........................] - ETA: 2s - loss: 0.0104 - acc: 0.9967
 4544/30596 [===>..........................] - ETA: 2s - loss: 0.0134 - acc: 0.9958
 5184/30596 [====>.........................] - ETA: 2s - loss: 0.0136 - acc: 0.9956
 5824/30596 [====>.........................] - ETA: 2s - loss: 0.0126 - acc: 0.9959
 6464/30596 [=====>........................] - ETA: 2s - loss: 0.0126 - acc: 0.9958
 7104/30596 [=====>........................] - ETA: 1s - loss: 0.0120 - acc: 0.9961
 7744/30596 [======>.......................] - ETA: 1s - loss: 0.0120 - acc: 0.9963
 8448/30596 [=======>......................] - ETA: 1s - loss: 0.0122 - acc: 0.9959
 9088/30596 [=======>......................] - ETA: 1s - loss: 0.0114 - acc: 0.9961
 9728/30596 [========>.....................] - ETA: 1s - loss: 0.0121 - acc: 0.9962
10432/30596 [=========>....................] - ETA: 1s - loss: 0.0129 - acc: 0.9960
11072/30596 [=========>....................] - ETA: 1s - loss: 0.0132 - acc: 0.9960
11712/30596 [==========>...................] - ETA: 1s - loss: 0.0127 - acc: 0.9962
12352/30596 [===========>..................] - ETA: 1s - loss: 0.0121 - acc: 0.9964
12992/30596 [===========>..................] - ETA: 1s - loss: 0.0127 - acc: 0.9962
13632/30596 [============>.................] - ETA: 1s - loss: 0.0125 - acc: 0.9963
14272/30596 [============>.................] - ETA: 1s - loss: 0.0123 - acc: 0.9962
14912/30596 [=============>................] - ETA: 1s - loss: 0.0124 - acc: 0.9962
15488/30596 [==============>...............] - ETA: 1s - loss: 0.0132 - acc: 0.9962
16128/30596 [==============>...............] - ETA: 1s - loss: 0.0129 - acc: 0.9963
16768/30596 [===============>..............] - ETA: 1s - loss: 0.0128 - acc: 0.9964
17408/30596 [================>.............] - ETA: 1s - loss: 0.0127 - acc: 0.9963
18112/30596 [================>.............] - ETA: 1s - loss: 0.0127 - acc: 0.9962
18816/30596 [=================>............] - ETA: 0s - loss: 0.0129 - acc: 0.9960
19520/30596 [==================>...........] - ETA: 0s - loss: 0.0128 - acc: 0.9960
20160/30596 [==================>...........] - ETA: 0s - loss: 0.0136 - acc: 0.9958
20736/30596 [===================>..........] - ETA: 0s - loss: 0.0135 - acc: 0.9959
21376/30596 [===================>..........] - ETA: 0s - loss: 0.0134 - acc: 0.9959
22016/30596 [====================>.........] - ETA: 0s - loss: 0.0135 - acc: 0.9958
22656/30596 [=====================>........] - ETA: 0s - loss: 0.0134 - acc: 0.9958
23296/30596 [=====================>........] - ETA: 0s - loss: 0.0132 - acc: 0.9958
23936/30596 [======================>.......] - ETA: 0s - loss: 0.0132 - acc: 0.9958
24576/30596 [=======================>......] - ETA: 0s - loss: 0.0134 - acc: 0.9957
25216/30596 [=======================>......] - ETA: 0s - loss: 0.0134 - acc: 0.9957
25856/30596 [========================>.....] - ETA: 0s - loss: 0.0133 - acc: 0.9957
26496/30596 [========================>.....] - ETA: 0s - loss: 0.0133 - acc: 0.9957
27136/30596 [=========================>....] - ETA: 0s - loss: 0.0131 - acc: 0.9958
27776/30596 [==========================>...] - ETA: 0s - loss: 0.0130 - acc: 0.9958
28416/30596 [==========================>...] - ETA: 0s - loss: 0.0129 - acc: 0.9958
29120/30596 [===========================>..] - ETA: 0s - loss: 0.0132 - acc: 0.9958
29760/30596 [============================>.] - ETA: 0s - loss: 0.0131 - acc: 0.9959
30400/30596 [============================>.] - ETA: 0s - loss: 0.0135 - acc: 0.9958
30596/30596 [==============================] - 3s 82us/step - loss: 0.0136 - acc: 0.9958
Epoch 1/5
   64/29404 [..............................] - ETA: 2s - loss: 0.4838 - acc: 0.8438
  704/29404 [..............................] - ETA: 2s - loss: 0.1796 - acc: 0.9446
 1344/29404 [>.............................] - ETA: 2s - loss: 0.1314 - acc: 0.9598
 1984/29404 [=>............................] - ETA: 2s - loss: 0.1069 - acc: 0.9667
 2624/29404 [=>............................] - ETA: 2s - loss: 0.1077 - acc: 0.9684
 3200/29404 [==>...........................] - ETA: 2s - loss: 0.0944 - acc: 0.9719
 3840/29404 [==>...........................] - ETA: 2s - loss: 0.0939 - acc: 0.9719
 4544/29404 [===>..........................] - ETA: 2s - loss: 0.0863 - acc: 0.9743
 5184/29404 [====>.........................] - ETA: 2s - loss: 0.0862 - acc: 0.9736
 5824/29404 [====>.........................] - ETA: 1s - loss: 0.0836 - acc: 0.9748
 6464/29404 [=====>........................] - ETA: 1s - loss: 0.0823 - acc: 0.9751
 7104/29404 [======>.......................] - ETA: 1s - loss: 0.0821 - acc: 0.9751
 7680/29404 [======>.......................] - ETA: 1s - loss: 0.0793 - acc: 0.9754
 8320/29404 [=======>......................] - ETA: 1s - loss: 0.0773 - acc: 0.9760
 8960/29404 [========>.....................] - ETA: 1s - loss: 0.0748 - acc: 0.9768
 9600/29404 [========>.....................] - ETA: 1s - loss: 0.0729 - acc: 0.9774
10304/29404 [=========>....................] - ETA: 1s - loss: 0.0697 - acc: 0.9784
10944/29404 [==========>...................] - ETA: 1s - loss: 0.0688 - acc: 0.9785
11584/29404 [==========>...................] - ETA: 1s - loss: 0.0689 - acc: 0.9786
12288/29404 [===========>..................] - ETA: 1s - loss: 0.0670 - acc: 0.9790
12992/29404 [============>.................] - ETA: 1s - loss: 0.0650 - acc: 0.9797
13632/29404 [============>.................] - ETA: 1s - loss: 0.0642 - acc: 0.9798
14336/29404 [=============>................] - ETA: 1s - loss: 0.0646 - acc: 0.9796
14976/29404 [==============>...............] - ETA: 1s - loss: 0.0649 - acc: 0.9796
15616/29404 [==============>...............] - ETA: 1s - loss: 0.0641 - acc: 0.9798
16256/29404 [===============>..............] - ETA: 1s - loss: 0.0638 - acc: 0.9799
16896/29404 [================>.............] - ETA: 1s - loss: 0.0634 - acc: 0.9801
17536/29404 [================>.............] - ETA: 0s - loss: 0.0618 - acc: 0.9806
18176/29404 [=================>............] - ETA: 0s - loss: 0.0618 - acc: 0.9807
18816/29404 [==================>...........] - ETA: 0s - loss: 0.0613 - acc: 0.9808
19520/29404 [==================>...........] - ETA: 0s - loss: 0.0604 - acc: 0.9811
20160/29404 [===================>..........] - ETA: 0s - loss: 0.0592 - acc: 0.9815
20800/29404 [====================>.........] - ETA: 0s - loss: 0.0586 - acc: 0.9817
21440/29404 [====================>.........] - ETA: 0s - loss: 0.0581 - acc: 0.9819
22080/29404 [=====================>........] - ETA: 0s - loss: 0.0575 - acc: 0.9822
22720/29404 [======================>.......] - ETA: 0s - loss: 0.0576 - acc: 0.9819
23360/29404 [======================>.......] - ETA: 0s - loss: 0.0571 - acc: 0.9821
24000/29404 [=======================>......] - ETA: 0s - loss: 0.0564 - acc: 0.9822
24640/29404 [========================>.....] - ETA: 0s - loss: 0.0555 - acc: 0.9825
25280/29404 [========================>.....] - ETA: 0s - loss: 0.0551 - acc: 0.9827
25856/29404 [=========================>....] - ETA: 0s - loss: 0.0549 - acc: 0.9828
26496/29404 [==========================>...] - ETA: 0s - loss: 0.0546 - acc: 0.9830
27136/29404 [==========================>...] - ETA: 0s - loss: 0.0541 - acc: 0.9831
27840/29404 [===========================>..] - ETA: 0s - loss: 0.0535 - acc: 0.9833
28544/29404 [============================>.] - ETA: 0s - loss: 0.0534 - acc: 0.9833
29248/29404 [============================>.] - ETA: 0s - loss: 0.0532 - acc: 0.9833
29404/29404 [==============================] - 2s 82us/step - loss: 0.0531 - acc: 0.9833
Epoch 2/5
   64/29404 [..............................] - ETA: 3s - loss: 0.0102 - acc: 1.0000
  704/29404 [..............................] - ETA: 2s - loss: 0.0569 - acc: 0.9844
 1344/29404 [>.............................] - ETA: 2s - loss: 0.0425 - acc: 0.9881
 1920/29404 [>.............................] - ETA: 2s - loss: 0.0363 - acc: 0.9896
 2560/29404 [=>............................] - ETA: 2s - loss: 0.0336 - acc: 0.9902
 3200/29404 [==>...........................] - ETA: 2s - loss: 0.0334 - acc: 0.9909
 3840/29404 [==>...........................] - ETA: 2s - loss: 0.0329 - acc: 0.9911
 4544/29404 [===>..........................] - ETA: 2s - loss: 0.0320 - acc: 0.9912
 5184/29404 [====>.........................] - ETA: 2s - loss: 0.0318 - acc: 0.9905
 5824/29404 [====>.........................] - ETA: 1s - loss: 0.0319 - acc: 0.9904
 6464/29404 [=====>........................] - ETA: 1s - loss: 0.0316 - acc: 0.9906
 7104/29404 [======>.......................] - ETA: 1s - loss: 0.0314 - acc: 0.9910
 7808/29404 [======>.......................] - ETA: 1s - loss: 0.0312 - acc: 0.9912
 8384/29404 [=======>......................] - ETA: 1s - loss: 0.0303 - acc: 0.9914
 9024/29404 [========>.....................] - ETA: 1s - loss: 0.0301 - acc: 0.9914
 9664/29404 [========>.....................] - ETA: 1s - loss: 0.0300 - acc: 0.9914
10304/29404 [=========>....................] - ETA: 1s - loss: 0.0306 - acc: 0.9913
11008/29404 [==========>...................] - ETA: 1s - loss: 0.0302 - acc: 0.9914
11648/29404 [==========>...................] - ETA: 1s - loss: 0.0295 - acc: 0.9915
12288/29404 [===========>..................] - ETA: 1s - loss: 0.0285 - acc: 0.9917
12928/29404 [============>.................] - ETA: 1s - loss: 0.0278 - acc: 0.9918
13568/29404 [============>.................] - ETA: 1s - loss: 0.0274 - acc: 0.9920
14208/29404 [=============>................] - ETA: 1s - loss: 0.0280 - acc: 0.9920
14784/29404 [==============>...............] - ETA: 1s - loss: 0.0275 - acc: 0.9922
15424/29404 [==============>...............] - ETA: 1s - loss: 0.0279 - acc: 0.9921
16064/29404 [===============>..............] - ETA: 1s - loss: 0.0288 - acc: 0.9918
16704/29404 [================>.............] - ETA: 1s - loss: 0.0282 - acc: 0.9919
17344/29404 [================>.............] - ETA: 1s - loss: 0.0275 - acc: 0.9920
18048/29404 [=================>............] - ETA: 0s - loss: 0.0275 - acc: 0.9920
18688/29404 [==================>...........] - ETA: 0s - loss: 0.0282 - acc: 0.9918
19328/29404 [==================>...........] - ETA: 0s - loss: 0.0284 - acc: 0.9917
19968/29404 [===================>..........] - ETA: 0s - loss: 0.0281 - acc: 0.9918
20544/29404 [===================>..........] - ETA: 0s - loss: 0.0279 - acc: 0.9919
21248/29404 [====================>.........] - ETA: 0s - loss: 0.0274 - acc: 0.9920
21824/29404 [=====================>........] - ETA: 0s - loss: 0.0274 - acc: 0.9921
22464/29404 [=====================>........] - ETA: 0s - loss: 0.0273 - acc: 0.9921
23104/29404 [======================>.......] - ETA: 0s - loss: 0.0271 - acc: 0.9922
23680/29404 [=======================>......] - ETA: 0s - loss: 0.0272 - acc: 0.9921
24320/29404 [=======================>......] - ETA: 0s - loss: 0.0269 - acc: 0.9921
25024/29404 [========================>.....] - ETA: 0s - loss: 0.0270 - acc: 0.9922
25664/29404 [=========================>....] - ETA: 0s - loss: 0.0269 - acc: 0.9921
26304/29404 [=========================>....] - ETA: 0s - loss: 0.0272 - acc: 0.9919
26880/29404 [==========================>...] - ETA: 0s - loss: 0.0272 - acc: 0.9920
27520/29404 [===========================>..] - ETA: 0s - loss: 0.0269 - acc: 0.9921
28160/29404 [===========================>..] - ETA: 0s - loss: 0.0271 - acc: 0.9921
28800/29404 [============================>.] - ETA: 0s - loss: 0.0272 - acc: 0.9920
29404/29404 [==============================] - 2s 83us/step - loss: 0.0270 - acc: 0.9920
Epoch 3/5
   64/29404 [..............................] - ETA: 2s - loss: 0.0932 - acc: 0.9844
  704/29404 [..............................] - ETA: 2s - loss: 0.0212 - acc: 0.9957
 1344/29404 [>.............................] - ETA: 2s - loss: 0.0221 - acc: 0.9955
 1984/29404 [=>............................] - ETA: 2s - loss: 0.0186 - acc: 0.9955
 2624/29404 [=>............................] - ETA: 2s - loss: 0.0221 - acc: 0.9939
 3264/29404 [==>...........................] - ETA: 2s - loss: 0.0186 - acc: 0.9951
 3904/29404 [==>...........................] - ETA: 2s - loss: 0.0204 - acc: 0.9946
 4544/29404 [===>..........................] - ETA: 2s - loss: 0.0212 - acc: 0.9947
 5184/29404 [====>.........................] - ETA: 1s - loss: 0.0237 - acc: 0.9942
 5824/29404 [====>.........................] - ETA: 1s - loss: 0.0219 - acc: 0.9947
 6464/29404 [=====>........................] - ETA: 1s - loss: 0.0206 - acc: 0.9949
 7040/29404 [======>.......................] - ETA: 1s - loss: 0.0198 - acc: 0.9952
 7680/29404 [======>.......................] - ETA: 1s - loss: 0.0186 - acc: 0.9954
 8320/29404 [=======>......................] - ETA: 1s - loss: 0.0184 - acc: 0.9954
 8960/29404 [========>.....................] - ETA: 1s - loss: 0.0182 - acc: 0.9953
 9600/29404 [========>.....................] - ETA: 1s - loss: 0.0179 - acc: 0.9953
10176/29404 [=========>....................] - ETA: 1s - loss: 0.0174 - acc: 0.9953
10816/29404 [==========>...................] - ETA: 1s - loss: 0.0176 - acc: 0.9954
11392/29404 [==========>...................] - ETA: 1s - loss: 0.0173 - acc: 0.9953
12096/29404 [===========>..................] - ETA: 1s - loss: 0.0178 - acc: 0.9952
12736/29404 [===========>..................] - ETA: 1s - loss: 0.0178 - acc: 0.9951
13312/29404 [============>.................] - ETA: 1s - loss: 0.0183 - acc: 0.9950
13952/29404 [=============>................] - ETA: 1s - loss: 0.0184 - acc: 0.9950
14528/29404 [=============>................] - ETA: 1s - loss: 0.0182 - acc: 0.9949
15168/29404 [==============>...............] - ETA: 1s - loss: 0.0184 - acc: 0.9949
15744/29404 [===============>..............] - ETA: 1s - loss: 0.0180 - acc: 0.9949
16384/29404 [===============>..............] - ETA: 1s - loss: 0.0179 - acc: 0.9949
17088/29404 [================>.............] - ETA: 1s - loss: 0.0176 - acc: 0.9950
17792/29404 [=================>............] - ETA: 0s - loss: 0.0178 - acc: 0.9949
18432/29404 [=================>............] - ETA: 0s - loss: 0.0182 - acc: 0.9947
19008/29404 [==================>...........] - ETA: 0s - loss: 0.0181 - acc: 0.9947
19648/29404 [===================>..........] - ETA: 0s - loss: 0.0182 - acc: 0.9946
20352/29404 [===================>..........] - ETA: 0s - loss: 0.0185 - acc: 0.9945
20928/29404 [====================>.........] - ETA: 0s - loss: 0.0181 - acc: 0.9946
21568/29404 [=====================>........] - ETA: 0s - loss: 0.0181 - acc: 0.9946
22208/29404 [=====================>........] - ETA: 0s - loss: 0.0185 - acc: 0.9945
22848/29404 [======================>.......] - ETA: 0s - loss: 0.0182 - acc: 0.9945
23552/29404 [=======================>......] - ETA: 0s - loss: 0.0184 - acc: 0.9946
24128/29404 [=======================>......] - ETA: 0s - loss: 0.0184 - acc: 0.9946
24704/29404 [========================>.....] - ETA: 0s - loss: 0.0182 - acc: 0.9946
25280/29404 [========================>.....] - ETA: 0s - loss: 0.0181 - acc: 0.9946
25920/29404 [=========================>....] - ETA: 0s - loss: 0.0179 - acc: 0.9947
26560/29404 [==========================>...] - ETA: 0s - loss: 0.0177 - acc: 0.9948
27264/29404 [==========================>...] - ETA: 0s - loss: 0.0176 - acc: 0.9948
27904/29404 [===========================>..] - ETA: 0s - loss: 0.0176 - acc: 0.9947
28480/29404 [============================>.] - ETA: 0s - loss: 0.0176 - acc: 0.9947
29120/29404 [============================>.] - ETA: 0s - loss: 0.0176 - acc: 0.9947
29404/29404 [==============================] - 2s 83us/step - loss: 0.0177 - acc: 0.9946
Epoch 4/5
   64/29404 [..............................] - ETA: 2s - loss: 0.0024 - acc: 1.0000
  704/29404 [..............................] - ETA: 2s - loss: 0.0135 - acc: 0.9929
 1280/29404 [>.............................] - ETA: 2s - loss: 0.0187 - acc: 0.9938
 1856/29404 [>.............................] - ETA: 2s - loss: 0.0157 - acc: 0.9941
 2432/29404 [=>............................] - ETA: 2s - loss: 0.0139 - acc: 0.9951
 3072/29404 [==>...........................] - ETA: 2s - loss: 0.0124 - acc: 0.9958
 3776/29404 [==>...........................] - ETA: 2s - loss: 0.0116 - acc: 0.9963
 4416/29404 [===>..........................] - ETA: 2s - loss: 0.0116 - acc: 0.9966
 5056/29404 [====>.........................] - ETA: 2s - loss: 0.0122 - acc: 0.9964
 5760/29404 [====>.........................] - ETA: 1s - loss: 0.0110 - acc: 0.9967
 6336/29404 [=====>........................] - ETA: 1s - loss: 0.0105 - acc: 0.9967
 6912/29404 [======>.......................] - ETA: 1s - loss: 0.0125 - acc: 0.9959
 7552/29404 [======>.......................] - ETA: 1s - loss: 0.0120 - acc: 0.9960
 8192/29404 [=======>......................] - ETA: 1s - loss: 0.0122 - acc: 0.9961
 8832/29404 [========>.....................] - ETA: 1s - loss: 0.0123 - acc: 0.9960
 9472/29404 [========>.....................] - ETA: 1s - loss: 0.0130 - acc: 0.9960
10112/29404 [=========>....................] - ETA: 1s - loss: 0.0129 - acc: 0.9960
10752/29404 [=========>....................] - ETA: 1s - loss: 0.0136 - acc: 0.9958
11392/29404 [==========>...................] - ETA: 1s - loss: 0.0131 - acc: 0.9960
11968/29404 [===========>..................] - ETA: 1s - loss: 0.0134 - acc: 0.9958
12608/29404 [===========>..................] - ETA: 1s - loss: 0.0129 - acc: 0.9960
13312/29404 [============>.................] - ETA: 1s - loss: 0.0124 - acc: 0.9962
13952/29404 [=============>................] - ETA: 1s - loss: 0.0125 - acc: 0.9962
14592/29404 [=============>................] - ETA: 1s - loss: 0.0131 - acc: 0.9960
15232/29404 [==============>...............] - ETA: 1s - loss: 0.0127 - acc: 0.9962
15872/29404 [===============>..............] - ETA: 1s - loss: 0.0128 - acc: 0.9962
16512/29404 [===============>..............] - ETA: 1s - loss: 0.0125 - acc: 0.9962
17216/29404 [================>.............] - ETA: 1s - loss: 0.0122 - acc: 0.9963
17856/29404 [=================>............] - ETA: 0s - loss: 0.0123 - acc: 0.9961
18432/29404 [=================>............] - ETA: 0s - loss: 0.0123 - acc: 0.9961
19136/29404 [==================>...........] - ETA: 0s - loss: 0.0125 - acc: 0.9960
19776/29404 [===================>..........] - ETA: 0s - loss: 0.0128 - acc: 0.9961
20416/29404 [===================>..........] - ETA: 0s - loss: 0.0125 - acc: 0.9962
21056/29404 [====================>.........] - ETA: 0s - loss: 0.0126 - acc: 0.9962
21696/29404 [=====================>........] - ETA: 0s - loss: 0.0124 - acc: 0.9962
22336/29404 [=====================>........] - ETA: 0s - loss: 0.0129 - acc: 0.9961
22976/29404 [======================>.......] - ETA: 0s - loss: 0.0134 - acc: 0.9960
23616/29404 [=======================>......] - ETA: 0s - loss: 0.0133 - acc: 0.9960
24256/29404 [=======================>......] - ETA: 0s - loss: 0.0131 - acc: 0.9960
24896/29404 [========================>.....] - ETA: 0s - loss: 0.0129 - acc: 0.9960
25536/29404 [=========================>....] - ETA: 0s - loss: 0.0132 - acc: 0.9959
26240/29404 [=========================>....] - ETA: 0s - loss: 0.0132 - acc: 0.9958
26880/29404 [==========================>...] - ETA: 0s - loss: 0.0130 - acc: 0.9959
27520/29404 [===========================>..] - ETA: 0s - loss: 0.0133 - acc: 0.9958
28160/29404 [===========================>..] - ETA: 0s - loss: 0.0133 - acc: 0.9958
28736/29404 [============================>.] - ETA: 0s - loss: 0.0132 - acc: 0.9958
29312/29404 [============================>.] - ETA: 0s - loss: 0.0132 - acc: 0.9957
29404/29404 [==============================] - 2s 83us/step - loss: 0.0132 - acc: 0.9957
Epoch 5/5
   64/29404 [..............................] - ETA: 2s - loss: 5.6362e-04 - acc: 1.0000
  768/29404 [..............................] - ETA: 2s - loss: 0.0031 - acc: 0.9987    
 1408/29404 [>.............................] - ETA: 2s - loss: 0.0027 - acc: 0.9993
 1984/29404 [=>............................] - ETA: 2s - loss: 0.0053 - acc: 0.9975
 2624/29404 [=>............................] - ETA: 2s - loss: 0.0048 - acc: 0.9977
 3264/29404 [==>...........................] - ETA: 2s - loss: 0.0055 - acc: 0.9979
 3904/29404 [==>...........................] - ETA: 2s - loss: 0.0073 - acc: 0.9974
 4544/29404 [===>..........................] - ETA: 2s - loss: 0.0082 - acc: 0.9967
 5184/29404 [====>.........................] - ETA: 1s - loss: 0.0084 - acc: 0.9967
 5824/29404 [====>.........................] - ETA: 1s - loss: 0.0081 - acc: 0.9969
 6464/29404 [=====>........................] - ETA: 1s - loss: 0.0081 - acc: 0.9969
 7104/29404 [======>.......................] - ETA: 1s - loss: 0.0075 - acc: 0.9972
 7808/29404 [======>.......................] - ETA: 1s - loss: 0.0079 - acc: 0.9971
 8448/29404 [=======>......................] - ETA: 1s - loss: 0.0083 - acc: 0.9968
 9024/29404 [========>.....................] - ETA: 1s - loss: 0.0081 - acc: 0.9969
 9664/29404 [========>.....................] - ETA: 1s - loss: 0.0088 - acc: 0.9965
10304/29404 [=========>....................] - ETA: 1s - loss: 0.0083 - acc: 0.9967
10944/29404 [==========>...................] - ETA: 1s - loss: 0.0081 - acc: 0.9969
11584/29404 [==========>...................] - ETA: 1s - loss: 0.0077 - acc: 0.9971
12160/29404 [===========>..................] - ETA: 1s - loss: 0.0074 - acc: 0.9972
12800/29404 [============>.................] - ETA: 1s - loss: 0.0073 - acc: 0.9972
13376/29404 [============>.................] - ETA: 1s - loss: 0.0080 - acc: 0.9969
14016/29404 [=============>................] - ETA: 1s - loss: 0.0092 - acc: 0.9967
14720/29404 [==============>...............] - ETA: 1s - loss: 0.0090 - acc: 0.9968
15360/29404 [==============>...............] - ETA: 1s - loss: 0.0095 - acc: 0.9965
16000/29404 [===============>..............] - ETA: 1s - loss: 0.0091 - acc: 0.9967
16576/29404 [===============>..............] - ETA: 1s - loss: 0.0091 - acc: 0.9967
17152/29404 [================>.............] - ETA: 1s - loss: 0.0090 - acc: 0.9967
17728/29404 [=================>............] - ETA: 0s - loss: 0.0096 - acc: 0.9966
18304/29404 [=================>............] - ETA: 0s - loss: 0.0098 - acc: 0.9966
18944/29404 [==================>...........] - ETA: 0s - loss: 0.0098 - acc: 0.9966
19584/29404 [==================>...........] - ETA: 0s - loss: 0.0097 - acc: 0.9966
20224/29404 [===================>..........] - ETA: 0s - loss: 0.0100 - acc: 0.9965
20864/29404 [====================>.........] - ETA: 0s - loss: 0.0098 - acc: 0.9966
21504/29404 [====================>.........] - ETA: 0s - loss: 0.0097 - acc: 0.9967
22080/29404 [=====================>........] - ETA: 0s - loss: 0.0096 - acc: 0.9967
22720/29404 [======================>.......] - ETA: 0s - loss: 0.0096 - acc: 0.9967
23360/29404 [======================>.......] - ETA: 0s - loss: 0.0097 - acc: 0.9966
24000/29404 [=======================>......] - ETA: 0s - loss: 0.0097 - acc: 0.9966
24640/29404 [========================>.....] - ETA: 0s - loss: 0.0096 - acc: 0.9966
25280/29404 [========================>.....] - ETA: 0s - loss: 0.0094 - acc: 0.9966
25920/29404 [=========================>....] - ETA: 0s - loss: 0.0094 - acc: 0.9966
26560/29404 [==========================>...] - ETA: 0s - loss: 0.0092 - acc: 0.9967
27136/29404 [==========================>...] - ETA: 0s - loss: 0.0093 - acc: 0.9966
27712/29404 [===========================>..] - ETA: 0s - loss: 0.0095 - acc: 0.9966
28352/29404 [===========================>..] - ETA: 0s - loss: 0.0093 - acc: 0.9966
28928/29404 [============================>.] - ETA: 0s - loss: 0.0093 - acc: 0.9966
29404/29404 [==============================] - 2s 84us/step - loss: 0.0093 - acc: 0.9967
   32/10000 [..............................] - ETA: 13s
 1088/10000 [==>...........................] - ETA: 0s 
 2048/10000 [=====>........................] - ETA: 0s
 3040/10000 [========>.....................] - ETA: 0s
 4000/10000 [===========>..................] - ETA: 0s
 4960/10000 [=============>................] - ETA: 0s
 5984/10000 [================>.............] - ETA: 0s
 6944/10000 [===================>..........] - ETA: 0s
 7904/10000 [======================>.......] - ETA: 0s
 8864/10000 [=========================>....] - ETA: 0s
 9824/10000 [============================>.] - ETA: 0s
10000/10000 [==============================] - 1s 57us/step
0.9495
Epoch 1/5
   64/60000 [..............................] - ETA: 4:05 - loss: 2.2960 - acc: 0.2188
  704/60000 [..............................] - ETA: 26s - loss: 2.0392 - acc: 0.3423 
 1280/60000 [..............................] - ETA: 16s - loss: 1.7102 - acc: 0.4430
 1920/60000 [..............................] - ETA: 12s - loss: 1.4245 - acc: 0.5479
 2560/60000 [>.............................] - ETA: 10s - loss: 1.2302 - acc: 0.6117
 3264/60000 [>.............................] - ETA: 9s - loss: 1.0777 - acc: 0.6599 
 3904/60000 [>.............................] - ETA: 8s - loss: 0.9964 - acc: 0.6878
 4544/60000 [=>............................] - ETA: 7s - loss: 0.9165 - acc: 0.7130
 5184/60000 [=>............................] - ETA: 7s - loss: 0.8473 - acc: 0.7359
 5824/60000 [=>............................] - ETA: 6s - loss: 0.7976 - acc: 0.7533
 6400/60000 [==>...........................] - ETA: 6s - loss: 0.7555 - acc: 0.7678
 7040/60000 [==>...........................] - ETA: 6s - loss: 0.7177 - acc: 0.7784
 7680/60000 [==>...........................] - ETA: 6s - loss: 0.6799 - acc: 0.7895
 8320/60000 [===>..........................] - ETA: 5s - loss: 0.6451 - acc: 0.8007
 8960/60000 [===>..........................] - ETA: 5s - loss: 0.6145 - acc: 0.8104
 9600/60000 [===>..........................] - ETA: 5s - loss: 0.5886 - acc: 0.8186
10176/60000 [====>.........................] - ETA: 5s - loss: 0.5698 - acc: 0.8241
10816/60000 [====>.........................] - ETA: 5s - loss: 0.5469 - acc: 0.8310
11456/60000 [====>.........................] - ETA: 5s - loss: 0.5257 - acc: 0.8371
12160/60000 [=====>........................] - ETA: 4s - loss: 0.5065 - acc: 0.8424
12736/60000 [=====>........................] - ETA: 4s - loss: 0.4891 - acc: 0.8476
13376/60000 [=====>........................] - ETA: 4s - loss: 0.4743 - acc: 0.8520
14016/60000 [======>.......................] - ETA: 4s - loss: 0.4619 - acc: 0.8560
14656/60000 [======>.......................] - ETA: 4s - loss: 0.4503 - acc: 0.8595
15296/60000 [======>.......................] - ETA: 4s - loss: 0.4377 - acc: 0.8634
15936/60000 [======>.......................] - ETA: 4s - loss: 0.4276 - acc: 0.8665
16576/60000 [=======>......................] - ETA: 4s - loss: 0.4170 - acc: 0.8698
17216/60000 [=======>......................] - ETA: 4s - loss: 0.4073 - acc: 0.8726
17856/60000 [=======>......................] - ETA: 4s - loss: 0.3964 - acc: 0.8762
18496/60000 [========>.....................] - ETA: 4s - loss: 0.3892 - acc: 0.8785
19136/60000 [========>.....................] - ETA: 3s - loss: 0.3796 - acc: 0.8812
19776/60000 [========>.....................] - ETA: 3s - loss: 0.3711 - acc: 0.8835
20416/60000 [=========>....................] - ETA: 3s - loss: 0.3635 - acc: 0.8857
20992/60000 [=========>....................] - ETA: 3s - loss: 0.3576 - acc: 0.8877
21632/60000 [=========>....................] - ETA: 3s - loss: 0.3502 - acc: 0.8901
22272/60000 [==========>...................] - ETA: 3s - loss: 0.3442 - acc: 0.8921
22912/60000 [==========>...................] - ETA: 3s - loss: 0.3374 - acc: 0.8941
23552/60000 [==========>...................] - ETA: 3s - loss: 0.3314 - acc: 0.8957
24128/60000 [===========>..................] - ETA: 3s - loss: 0.3259 - acc: 0.8975
24768/60000 [===========>..................] - ETA: 3s - loss: 0.3204 - acc: 0.8992
25408/60000 [===========>..................] - ETA: 3s - loss: 0.3148 - acc: 0.9010
26048/60000 [============>.................] - ETA: 3s - loss: 0.3088 - acc: 0.9029
26688/60000 [============>.................] - ETA: 3s - loss: 0.3041 - acc: 0.9043
27328/60000 [============>.................] - ETA: 3s - loss: 0.3003 - acc: 0.9055
27968/60000 [============>.................] - ETA: 2s - loss: 0.2956 - acc: 0.9069
28608/60000 [=============>................] - ETA: 2s - loss: 0.2912 - acc: 0.9082
29312/60000 [=============>................] - ETA: 2s - loss: 0.2861 - acc: 0.9098
29888/60000 [=============>................] - ETA: 2s - loss: 0.2824 - acc: 0.9109
30464/60000 [==============>...............] - ETA: 2s - loss: 0.2792 - acc: 0.9119
31104/60000 [==============>...............] - ETA: 2s - loss: 0.2760 - acc: 0.9129
31744/60000 [==============>...............] - ETA: 2s - loss: 0.2726 - acc: 0.9140
32384/60000 [===============>..............] - ETA: 2s - loss: 0.2692 - acc: 0.9151
33024/60000 [===============>..............] - ETA: 2s - loss: 0.2658 - acc: 0.9162
33664/60000 [===============>..............] - ETA: 2s - loss: 0.2621 - acc: 0.9174
34304/60000 [================>.............] - ETA: 2s - loss: 0.2583 - acc: 0.9185
34944/60000 [================>.............] - ETA: 2s - loss: 0.2556 - acc: 0.9195
35584/60000 [================>.............] - ETA: 2s - loss: 0.2529 - acc: 0.9203
36160/60000 [=================>............] - ETA: 2s - loss: 0.2506 - acc: 0.9209
36736/60000 [=================>............] - ETA: 2s - loss: 0.2476 - acc: 0.9218
37376/60000 [=================>............] - ETA: 2s - loss: 0.2451 - acc: 0.9227
38016/60000 [==================>...........] - ETA: 1s - loss: 0.2426 - acc: 0.9235
38656/60000 [==================>...........] - ETA: 1s - loss: 0.2396 - acc: 0.9244
39296/60000 [==================>...........] - ETA: 1s - loss: 0.2368 - acc: 0.9252
39872/60000 [==================>...........] - ETA: 1s - loss: 0.2341 - acc: 0.9260
40512/60000 [===================>..........] - ETA: 1s - loss: 0.2322 - acc: 0.9267
41152/60000 [===================>..........] - ETA: 1s - loss: 0.2294 - acc: 0.9276
41792/60000 [===================>..........] - ETA: 1s - loss: 0.2271 - acc: 0.9284
42432/60000 [====================>.........] - ETA: 1s - loss: 0.2249 - acc: 0.9290
43072/60000 [====================>.........] - ETA: 1s - loss: 0.2225 - acc: 0.9298
43648/60000 [====================>.........] - ETA: 1s - loss: 0.2211 - acc: 0.9302
44224/60000 [=====================>........] - ETA: 1s - loss: 0.2192 - acc: 0.9308
44864/60000 [=====================>........] - ETA: 1s - loss: 0.2169 - acc: 0.9315
45504/60000 [=====================>........] - ETA: 1s - loss: 0.2154 - acc: 0.9320
46144/60000 [======================>.......] - ETA: 1s - loss: 0.2137 - acc: 0.9326
46784/60000 [======================>.......] - ETA: 1s - loss: 0.2116 - acc: 0.9332
47488/60000 [======================>.......] - ETA: 1s - loss: 0.2095 - acc: 0.9340
48128/60000 [=======================>......] - ETA: 1s - loss: 0.2078 - acc: 0.9344
48768/60000 [=======================>......] - ETA: 0s - loss: 0.2059 - acc: 0.9350
49344/60000 [=======================>......] - ETA: 0s - loss: 0.2043 - acc: 0.9355
50112/60000 [========================>.....] - ETA: 0s - loss: 0.2020 - acc: 0.9362
50752/60000 [========================>.....] - ETA: 0s - loss: 0.2004 - acc: 0.9368
51392/60000 [========================>.....] - ETA: 0s - loss: 0.1986 - acc: 0.9373
52032/60000 [=========================>....] - ETA: 0s - loss: 0.1970 - acc: 0.9379
52672/60000 [=========================>....] - ETA: 0s - loss: 0.1957 - acc: 0.9383
53248/60000 [=========================>....] - ETA: 0s - loss: 0.1942 - acc: 0.9388
53888/60000 [=========================>....] - ETA: 0s - loss: 0.1922 - acc: 0.9394
54464/60000 [==========================>...] - ETA: 0s - loss: 0.1914 - acc: 0.9397
55104/60000 [==========================>...] - ETA: 0s - loss: 0.1901 - acc: 0.9401
55744/60000 [==========================>...] - ETA: 0s - loss: 0.1885 - acc: 0.9406
56384/60000 [===========================>..] - ETA: 0s - loss: 0.1870 - acc: 0.9411
57024/60000 [===========================>..] - ETA: 0s - loss: 0.1857 - acc: 0.9416
57600/60000 [===========================>..] - ETA: 0s - loss: 0.1842 - acc: 0.9420
58176/60000 [============================>.] - ETA: 0s - loss: 0.1835 - acc: 0.9422
58880/60000 [============================>.] - ETA: 0s - loss: 0.1820 - acc: 0.9427
59520/60000 [============================>.] - ETA: 0s - loss: 0.1806 - acc: 0.9432
60000/60000 [==============================] - 5s 88us/step - loss: 0.1796 - acc: 0.9434
Epoch 2/5
   64/60000 [..............................] - ETA: 5s - loss: 0.0404 - acc: 1.0000
  704/60000 [..............................] - ETA: 4s - loss: 0.0472 - acc: 0.9858
 1344/60000 [..............................] - ETA: 4s - loss: 0.0450 - acc: 0.9859
 1984/60000 [..............................] - ETA: 4s - loss: 0.0456 - acc: 0.9869
 2688/60000 [>.............................] - ETA: 4s - loss: 0.0411 - acc: 0.9885
 3328/60000 [>.............................] - ETA: 4s - loss: 0.0448 - acc: 0.9865
 3968/60000 [>.............................] - ETA: 4s - loss: 0.0489 - acc: 0.9849
 4608/60000 [=>............................] - ETA: 4s - loss: 0.0521 - acc: 0.9837
 5248/60000 [=>............................] - ETA: 4s - loss: 0.0514 - acc: 0.9840
 5888/60000 [=>............................] - ETA: 4s - loss: 0.0513 - acc: 0.9839
 6528/60000 [==>...........................] - ETA: 4s - loss: 0.0541 - acc: 0.9828
 7168/60000 [==>...........................] - ETA: 4s - loss: 0.0528 - acc: 0.9830
 7808/60000 [==>...........................] - ETA: 4s - loss: 0.0520 - acc: 0.9834
 8448/60000 [===>..........................] - ETA: 4s - loss: 0.0513 - acc: 0.9835
 9088/60000 [===>..........................] - ETA: 4s - loss: 0.0510 - acc: 0.9837
 9792/60000 [===>..........................] - ETA: 4s - loss: 0.0505 - acc: 0.9841
10432/60000 [====>.........................] - ETA: 4s - loss: 0.0510 - acc: 0.9840
11072/60000 [====>.........................] - ETA: 3s - loss: 0.0515 - acc: 0.9840
11712/60000 [====>.........................] - ETA: 3s - loss: 0.0529 - acc: 0.9839
12352/60000 [=====>........................] - ETA: 3s - loss: 0.0538 - acc: 0.9836
12992/60000 [=====>........................] - ETA: 3s - loss: 0.0538 - acc: 0.9835
13632/60000 [=====>........................] - ETA: 3s - loss: 0.0533 - acc: 0.9835
14208/60000 [======>.......................] - ETA: 3s - loss: 0.0527 - acc: 0.9836
14848/60000 [======>.......................] - ETA: 3s - loss: 0.0547 - acc: 0.9833
15488/60000 [======>.......................] - ETA: 3s - loss: 0.0548 - acc: 0.9833
16128/60000 [=======>......................] - ETA: 3s - loss: 0.0547 - acc: 0.9835
16768/60000 [=======>......................] - ETA: 3s - loss: 0.0540 - acc: 0.9836
17472/60000 [=======>......................] - ETA: 3s - loss: 0.0536 - acc: 0.9837
18112/60000 [========>.....................] - ETA: 3s - loss: 0.0527 - acc: 0.9839
18752/60000 [========>.....................] - ETA: 3s - loss: 0.0518 - acc: 0.9841
19328/60000 [========>.....................] - ETA: 3s - loss: 0.0519 - acc: 0.9838
19968/60000 [========>.....................] - ETA: 3s - loss: 0.0514 - acc: 0.9838
20608/60000 [=========>....................] - ETA: 3s - loss: 0.0516 - acc: 0.9838
21248/60000 [=========>....................] - ETA: 3s - loss: 0.0509 - acc: 0.9839
21888/60000 [=========>....................] - ETA: 3s - loss: 0.0504 - acc: 0.9839
22528/60000 [==========>...................] - ETA: 3s - loss: 0.0501 - acc: 0.9840
23168/60000 [==========>...................] - ETA: 3s - loss: 0.0504 - acc: 0.9838
23744/60000 [==========>...................] - ETA: 2s - loss: 0.0501 - acc: 0.9839
24384/60000 [===========>..................] - ETA: 2s - loss: 0.0496 - acc: 0.9841
25024/60000 [===========>..................] - ETA: 2s - loss: 0.0498 - acc: 0.9840
25664/60000 [===========>..................] - ETA: 2s - loss: 0.0494 - acc: 0.9841
26240/60000 [============>.................] - ETA: 2s - loss: 0.0496 - acc: 0.9841
26816/60000 [============>.................] - ETA: 2s - loss: 0.0498 - acc: 0.9841
27392/60000 [============>.................] - ETA: 2s - loss: 0.0497 - acc: 0.9842
28032/60000 [=============>................] - ETA: 2s - loss: 0.0494 - acc: 0.9842
28672/60000 [=============>................] - ETA: 2s - loss: 0.0489 - acc: 0.9843
29312/60000 [=============>................] - ETA: 2s - loss: 0.0492 - acc: 0.9843
29888/60000 [=============>................] - ETA: 2s - loss: 0.0496 - acc: 0.9842
30528/60000 [==============>...............] - ETA: 2s - loss: 0.0498 - acc: 0.9841
31168/60000 [==============>...............] - ETA: 2s - loss: 0.0497 - acc: 0.9842
31808/60000 [==============>...............] - ETA: 2s - loss: 0.0494 - acc: 0.9842
32512/60000 [===============>..............] - ETA: 2s - loss: 0.0493 - acc: 0.9842
33216/60000 [===============>..............] - ETA: 2s - loss: 0.0492 - acc: 0.9843
33856/60000 [===============>..............] - ETA: 2s - loss: 0.0496 - acc: 0.9841
34496/60000 [================>.............] - ETA: 2s - loss: 0.0495 - acc: 0.9842
35136/60000 [================>.............] - ETA: 2s - loss: 0.0491 - acc: 0.9843
35712/60000 [================>.............] - ETA: 2s - loss: 0.0496 - acc: 0.9843
36352/60000 [=================>............] - ETA: 1s - loss: 0.0491 - acc: 0.9844
36928/60000 [=================>............] - ETA: 1s - loss: 0.0490 - acc: 0.9845
37568/60000 [=================>............] - ETA: 1s - loss: 0.0494 - acc: 0.9844
38208/60000 [==================>...........] - ETA: 1s - loss: 0.0490 - acc: 0.9846
38848/60000 [==================>...........] - ETA: 1s - loss: 0.0487 - acc: 0.9846
39424/60000 [==================>...........] - ETA: 1s - loss: 0.0484 - acc: 0.9847
40064/60000 [===================>..........] - ETA: 1s - loss: 0.0483 - acc: 0.9848
40704/60000 [===================>..........] - ETA: 1s - loss: 0.0481 - acc: 0.9848
41344/60000 [===================>..........] - ETA: 1s - loss: 0.0477 - acc: 0.9850
41984/60000 [===================>..........] - ETA: 1s - loss: 0.0477 - acc: 0.9850
42624/60000 [====================>.........] - ETA: 1s - loss: 0.0476 - acc: 0.9850
43200/60000 [====================>.........] - ETA: 1s - loss: 0.0475 - acc: 0.9851
43776/60000 [====================>.........] - ETA: 1s - loss: 0.0476 - acc: 0.9850
44416/60000 [=====================>........] - ETA: 1s - loss: 0.0477 - acc: 0.9851
45056/60000 [=====================>........] - ETA: 1s - loss: 0.0478 - acc: 0.9850
45696/60000 [=====================>........] - ETA: 1s - loss: 0.0476 - acc: 0.9850
46336/60000 [======================>.......] - ETA: 1s - loss: 0.0472 - acc: 0.9852
46976/60000 [======================>.......] - ETA: 1s - loss: 0.0469 - acc: 0.9853
47616/60000 [======================>.......] - ETA: 1s - loss: 0.0471 - acc: 0.9852
48256/60000 [=======================>......] - ETA: 0s - loss: 0.0468 - acc: 0.9853
48896/60000 [=======================>......] - ETA: 0s - loss: 0.0466 - acc: 0.9854
49472/60000 [=======================>......] - ETA: 0s - loss: 0.0468 - acc: 0.9853
50112/60000 [========================>.....] - ETA: 0s - loss: 0.0469 - acc: 0.9852
50752/60000 [========================>.....] - ETA: 0s - loss: 0.0468 - acc: 0.9853
51392/60000 [========================>.....] - ETA: 0s - loss: 0.0467 - acc: 0.9853
51968/60000 [========================>.....] - ETA: 0s - loss: 0.0466 - acc: 0.9854
52672/60000 [=========================>....] - ETA: 0s - loss: 0.0465 - acc: 0.9854
53312/60000 [=========================>....] - ETA: 0s - loss: 0.0464 - acc: 0.9855
53952/60000 [=========================>....] - ETA: 0s - loss: 0.0466 - acc: 0.9854
54592/60000 [==========================>...] - ETA: 0s - loss: 0.0463 - acc: 0.9855
55232/60000 [==========================>...] - ETA: 0s - loss: 0.0462 - acc: 0.9856
55808/60000 [==========================>...] - ETA: 0s - loss: 0.0462 - acc: 0.9856
56448/60000 [===========================>..] - ETA: 0s - loss: 0.0461 - acc: 0.9856
57024/60000 [===========================>..] - ETA: 0s - loss: 0.0465 - acc: 0.9856
57664/60000 [===========================>..] - ETA: 0s - loss: 0.0465 - acc: 0.9856
58240/60000 [============================>.] - ETA: 0s - loss: 0.0464 - acc: 0.9856
58880/60000 [============================>.] - ETA: 0s - loss: 0.0465 - acc: 0.9855
59456/60000 [============================>.] - ETA: 0s - loss: 0.0463 - acc: 0.9855
60000/60000 [==============================] - 5s 83us/step - loss: 0.0462 - acc: 0.9856
Epoch 3/5
   64/60000 [..............................] - ETA: 5s - loss: 0.0267 - acc: 0.9844
  768/60000 [..............................] - ETA: 4s - loss: 0.0285 - acc: 0.9935
 1344/60000 [..............................] - ETA: 4s - loss: 0.0311 - acc: 0.9918
 1920/60000 [..............................] - ETA: 4s - loss: 0.0346 - acc: 0.9901
 2496/60000 [>.............................] - ETA: 4s - loss: 0.0360 - acc: 0.9900
 3072/60000 [>.............................] - ETA: 4s - loss: 0.0390 - acc: 0.9889
 3648/60000 [>.............................] - ETA: 4s - loss: 0.0379 - acc: 0.9888
 4352/60000 [=>............................] - ETA: 4s - loss: 0.0350 - acc: 0.9901
 5056/60000 [=>............................] - ETA: 4s - loss: 0.0380 - acc: 0.9895
 5696/60000 [=>............................] - ETA: 4s - loss: 0.0381 - acc: 0.9902
 6336/60000 [==>...........................] - ETA: 4s - loss: 0.0409 - acc: 0.9896
 6976/60000 [==>...........................] - ETA: 4s - loss: 0.0415 - acc: 0.9892
 7552/60000 [==>...........................] - ETA: 4s - loss: 0.0404 - acc: 0.9894
 8192/60000 [===>..........................] - ETA: 4s - loss: 0.0385 - acc: 0.9897
 8768/60000 [===>..........................] - ETA: 4s - loss: 0.0372 - acc: 0.9896
 9344/60000 [===>..........................] - ETA: 4s - loss: 0.0357 - acc: 0.9900
 9984/60000 [===>..........................] - ETA: 4s - loss: 0.0350 - acc: 0.9902
10688/60000 [====>.........................] - ETA: 4s - loss: 0.0345 - acc: 0.9904
11328/60000 [====>.........................] - ETA: 4s - loss: 0.0344 - acc: 0.9903
11968/60000 [====>.........................] - ETA: 3s - loss: 0.0353 - acc: 0.9902
12544/60000 [=====>........................] - ETA: 3s - loss: 0.0346 - acc: 0.9904
13184/60000 [=====>........................] - ETA: 3s - loss: 0.0347 - acc: 0.9904
13760/60000 [=====>........................] - ETA: 3s - loss: 0.0342 - acc: 0.9905
14400/60000 [======>.......................] - ETA: 3s - loss: 0.0334 - acc: 0.9906
15040/60000 [======>.......................] - ETA: 3s - loss: 0.0343 - acc: 0.9904
15680/60000 [======>.......................] - ETA: 3s - loss: 0.0343 - acc: 0.9904
16256/60000 [=======>......................] - ETA: 3s - loss: 0.0335 - acc: 0.9906
16896/60000 [=======>......................] - ETA: 3s - loss: 0.0333 - acc: 0.9905
17536/60000 [=======>......................] - ETA: 3s - loss: 0.0333 - acc: 0.9905
18176/60000 [========>.....................] - ETA: 3s - loss: 0.0332 - acc: 0.9906
18752/60000 [========>.....................] - ETA: 3s - loss: 0.0331 - acc: 0.9907
19392/60000 [========>.....................] - ETA: 3s - loss: 0.0323 - acc: 0.9909
19968/60000 [========>.....................] - ETA: 3s - loss: 0.0320 - acc: 0.9909
20608/60000 [=========>....................] - ETA: 3s - loss: 0.0318 - acc: 0.9908
21248/60000 [=========>....................] - ETA: 3s - loss: 0.0322 - acc: 0.9907
21824/60000 [=========>....................] - ETA: 3s - loss: 0.0320 - acc: 0.9907
22400/60000 [==========>...................] - ETA: 3s - loss: 0.0315 - acc: 0.9909
22976/60000 [==========>...................] - ETA: 3s - loss: 0.0313 - acc: 0.9909
23616/60000 [==========>...................] - ETA: 3s - loss: 0.0309 - acc: 0.9912
24256/60000 [===========>..................] - ETA: 3s - loss: 0.0312 - acc: 0.9911
24896/60000 [===========>..................] - ETA: 2s - loss: 0.0312 - acc: 0.9910
25536/60000 [===========>..................] - ETA: 2s - loss: 0.0321 - acc: 0.9909
26112/60000 [============>.................] - ETA: 2s - loss: 0.0323 - acc: 0.9908
26688/60000 [============>.................] - ETA: 2s - loss: 0.0323 - acc: 0.9908
27264/60000 [============>.................] - ETA: 2s - loss: 0.0324 - acc: 0.9909
27904/60000 [============>.................] - ETA: 2s - loss: 0.0325 - acc: 0.9908
28480/60000 [=============>................] - ETA: 2s - loss: 0.0321 - acc: 0.9908
29056/60000 [=============>................] - ETA: 2s - loss: 0.0320 - acc: 0.9908
29696/60000 [=============>................] - ETA: 2s - loss: 0.0316 - acc: 0.9909
30272/60000 [==============>...............] - ETA: 2s - loss: 0.0315 - acc: 0.9909
30912/60000 [==============>...............] - ETA: 2s - loss: 0.0312 - acc: 0.9910
31552/60000 [==============>...............] - ETA: 2s - loss: 0.0311 - acc: 0.9909
32192/60000 [===============>..............] - ETA: 2s - loss: 0.0311 - acc: 0.9910
32896/60000 [===============>..............] - ETA: 2s - loss: 0.0309 - acc: 0.9911
33536/60000 [===============>..............] - ETA: 2s - loss: 0.0310 - acc: 0.9911
34176/60000 [================>.............] - ETA: 2s - loss: 0.0307 - acc: 0.9912
34752/60000 [================>.............] - ETA: 2s - loss: 0.0306 - acc: 0.9912
35328/60000 [================>.............] - ETA: 2s - loss: 0.0309 - acc: 0.9911
35904/60000 [================>.............] - ETA: 2s - loss: 0.0306 - acc: 0.9912
36544/60000 [=================>............] - ETA: 1s - loss: 0.0309 - acc: 0.9911
37248/60000 [=================>............] - ETA: 1s - loss: 0.0312 - acc: 0.9910
37888/60000 [=================>............] - ETA: 1s - loss: 0.0310 - acc: 0.9911
38528/60000 [==================>...........] - ETA: 1s - loss: 0.0313 - acc: 0.9910
39168/60000 [==================>...........] - ETA: 1s - loss: 0.0311 - acc: 0.9911
39872/60000 [==================>...........] - ETA: 1s - loss: 0.0310 - acc: 0.9911
40512/60000 [===================>..........] - ETA: 1s - loss: 0.0314 - acc: 0.9910
41152/60000 [===================>..........] - ETA: 1s - loss: 0.0317 - acc: 0.9910
41728/60000 [===================>..........] - ETA: 1s - loss: 0.0320 - acc: 0.9909
42432/60000 [====================>.........] - ETA: 1s - loss: 0.0319 - acc: 0.9910
43072/60000 [====================>.........] - ETA: 1s - loss: 0.0317 - acc: 0.9910
43712/60000 [====================>.........] - ETA: 1s - loss: 0.0315 - acc: 0.9911
44352/60000 [=====================>........] - ETA: 1s - loss: 0.0317 - acc: 0.9910
44992/60000 [=====================>........] - ETA: 1s - loss: 0.0315 - acc: 0.9910
45632/60000 [=====================>........] - ETA: 1s - loss: 0.0315 - acc: 0.9911
46272/60000 [======================>.......] - ETA: 1s - loss: 0.0319 - acc: 0.9910
46976/60000 [======================>.......] - ETA: 1s - loss: 0.0320 - acc: 0.9910
47616/60000 [======================>.......] - ETA: 1s - loss: 0.0318 - acc: 0.9910
48256/60000 [=======================>......] - ETA: 0s - loss: 0.0315 - acc: 0.9911
48896/60000 [=======================>......] - ETA: 0s - loss: 0.0316 - acc: 0.9910
49472/60000 [=======================>......] - ETA: 0s - loss: 0.0316 - acc: 0.9910
50112/60000 [========================>.....] - ETA: 0s - loss: 0.0314 - acc: 0.9911
50752/60000 [========================>.....] - ETA: 0s - loss: 0.0316 - acc: 0.9910
51328/60000 [========================>.....] - ETA: 0s - loss: 0.0315 - acc: 0.9910
51968/60000 [========================>.....] - ETA: 0s - loss: 0.0315 - acc: 0.9909
52608/60000 [=========================>....] - ETA: 0s - loss: 0.0314 - acc: 0.9909
53184/60000 [=========================>....] - ETA: 0s - loss: 0.0312 - acc: 0.9910
53824/60000 [=========================>....] - ETA: 0s - loss: 0.0311 - acc: 0.9910
54464/60000 [==========================>...] - ETA: 0s - loss: 0.0314 - acc: 0.9908
55040/60000 [==========================>...] - ETA: 0s - loss: 0.0318 - acc: 0.9907
55744/60000 [==========================>...] - ETA: 0s - loss: 0.0317 - acc: 0.9907
56384/60000 [===========================>..] - ETA: 0s - loss: 0.0315 - acc: 0.9908
57024/60000 [===========================>..] - ETA: 0s - loss: 0.0313 - acc: 0.9909
57664/60000 [===========================>..] - ETA: 0s - loss: 0.0312 - acc: 0.9909
58304/60000 [============================>.] - ETA: 0s - loss: 0.0310 - acc: 0.9910
58944/60000 [============================>.] - ETA: 0s - loss: 0.0310 - acc: 0.9909
59520/60000 [============================>.] - ETA: 0s - loss: 0.0312 - acc: 0.9909
60000/60000 [==============================] - 5s 84us/step - loss: 0.0312 - acc: 0.9909
Epoch 4/5
   64/60000 [..............................] - ETA: 7s - loss: 0.0154 - acc: 0.9844
  640/60000 [..............................] - ETA: 5s - loss: 0.0163 - acc: 0.9938
 1280/60000 [..............................] - ETA: 5s - loss: 0.0114 - acc: 0.9969
 1920/60000 [..............................] - ETA: 5s - loss: 0.0131 - acc: 0.9964
 2560/60000 [>.............................] - ETA: 4s - loss: 0.0131 - acc: 0.9965
 3200/60000 [>.............................] - ETA: 4s - loss: 0.0170 - acc: 0.9956
 3840/60000 [>.............................] - ETA: 4s - loss: 0.0182 - acc: 0.9948
 4544/60000 [=>............................] - ETA: 4s - loss: 0.0208 - acc: 0.9934
 5120/60000 [=>............................] - ETA: 4s - loss: 0.0205 - acc: 0.9932
 5696/60000 [=>............................] - ETA: 4s - loss: 0.0205 - acc: 0.9932
 6336/60000 [==>...........................] - ETA: 4s - loss: 0.0209 - acc: 0.9934
 6976/60000 [==>...........................] - ETA: 4s - loss: 0.0205 - acc: 0.9934
 7680/60000 [==>...........................] - ETA: 4s - loss: 0.0207 - acc: 0.9935
 8320/60000 [===>..........................] - ETA: 4s - loss: 0.0205 - acc: 0.9934
 8960/60000 [===>..........................] - ETA: 4s - loss: 0.0223 - acc: 0.9935
 9664/60000 [===>..........................] - ETA: 4s - loss: 0.0221 - acc: 0.9935
10304/60000 [====>.........................] - ETA: 4s - loss: 0.0216 - acc: 0.9934
10880/60000 [====>.........................] - ETA: 4s - loss: 0.0211 - acc: 0.9936
11520/60000 [====>.........................] - ETA: 4s - loss: 0.0218 - acc: 0.9931
12224/60000 [=====>........................] - ETA: 3s - loss: 0.0212 - acc: 0.9931
12928/60000 [=====>........................] - ETA: 3s - loss: 0.0216 - acc: 0.9930
13504/60000 [=====>........................] - ETA: 3s - loss: 0.0211 - acc: 0.9932
14144/60000 [======>.......................] - ETA: 3s - loss: 0.0208 - acc: 0.9933
14784/60000 [======>.......................] - ETA: 3s - loss: 0.0223 - acc: 0.9932
15360/60000 [======>.......................] - ETA: 3s - loss: 0.0226 - acc: 0.9930
16000/60000 [=======>......................] - ETA: 3s - loss: 0.0220 - acc: 0.9932
16576/60000 [=======>......................] - ETA: 3s - loss: 0.0221 - acc: 0.9932
17216/60000 [=======>......................] - ETA: 3s - loss: 0.0215 - acc: 0.9935
17856/60000 [=======>......................] - ETA: 3s - loss: 0.0215 - acc: 0.9934
18560/60000 [========>.....................] - ETA: 3s - loss: 0.0210 - acc: 0.9935
19200/60000 [========>.....................] - ETA: 3s - loss: 0.0213 - acc: 0.9934
19776/60000 [========>.....................] - ETA: 3s - loss: 0.0213 - acc: 0.9934
20352/60000 [=========>....................] - ETA: 3s - loss: 0.0213 - acc: 0.9933
20992/60000 [=========>....................] - ETA: 3s - loss: 0.0222 - acc: 0.9930
21632/60000 [=========>....................] - ETA: 3s - loss: 0.0222 - acc: 0.9930
22272/60000 [==========>...................] - ETA: 3s - loss: 0.0224 - acc: 0.9930
22848/60000 [==========>...................] - ETA: 3s - loss: 0.0225 - acc: 0.9929
23488/60000 [==========>...................] - ETA: 3s - loss: 0.0225 - acc: 0.9929
24128/60000 [===========>..................] - ETA: 2s - loss: 0.0221 - acc: 0.9931
24768/60000 [===========>..................] - ETA: 2s - loss: 0.0222 - acc: 0.9930
25472/60000 [===========>..................] - ETA: 2s - loss: 0.0220 - acc: 0.9931
26048/60000 [============>.................] - ETA: 2s - loss: 0.0217 - acc: 0.9932
26624/60000 [============>.................] - ETA: 2s - loss: 0.0220 - acc: 0.9932
27200/60000 [============>.................] - ETA: 2s - loss: 0.0219 - acc: 0.9932
27840/60000 [============>.................] - ETA: 2s - loss: 0.0218 - acc: 0.9933
28480/60000 [=============>................] - ETA: 2s - loss: 0.0226 - acc: 0.9930
29120/60000 [=============>................] - ETA: 2s - loss: 0.0226 - acc: 0.9930
29760/60000 [=============>................] - ETA: 2s - loss: 0.0228 - acc: 0.9930
30400/60000 [==============>...............] - ETA: 2s - loss: 0.0232 - acc: 0.9929
31040/60000 [==============>...............] - ETA: 2s - loss: 0.0233 - acc: 0.9929
31680/60000 [==============>...............] - ETA: 2s - loss: 0.0230 - acc: 0.9930
32320/60000 [===============>..............] - ETA: 2s - loss: 0.0231 - acc: 0.9929
32960/60000 [===============>..............] - ETA: 2s - loss: 0.0230 - acc: 0.9929
33600/60000 [===============>..............] - ETA: 2s - loss: 0.0230 - acc: 0.9929
34240/60000 [================>.............] - ETA: 2s - loss: 0.0230 - acc: 0.9929
34880/60000 [================>.............] - ETA: 2s - loss: 0.0232 - acc: 0.9929
35520/60000 [================>.............] - ETA: 2s - loss: 0.0231 - acc: 0.9929
36224/60000 [=================>............] - ETA: 1s - loss: 0.0232 - acc: 0.9929
36864/60000 [=================>............] - ETA: 1s - loss: 0.0231 - acc: 0.9930
37504/60000 [=================>............] - ETA: 1s - loss: 0.0230 - acc: 0.9930
38144/60000 [==================>...........] - ETA: 1s - loss: 0.0231 - acc: 0.9930
38784/60000 [==================>...........] - ETA: 1s - loss: 0.0231 - acc: 0.9929
39424/60000 [==================>...........] - ETA: 1s - loss: 0.0232 - acc: 0.9928
40064/60000 [===================>..........] - ETA: 1s - loss: 0.0231 - acc: 0.9929
40704/60000 [===================>..........] - ETA: 1s - loss: 0.0232 - acc: 0.9929
41408/60000 [===================>..........] - ETA: 1s - loss: 0.0235 - acc: 0.9929
42048/60000 [====================>.........] - ETA: 1s - loss: 0.0235 - acc: 0.9928
42688/60000 [====================>.........] - ETA: 1s - loss: 0.0235 - acc: 0.9929
43264/60000 [====================>.........] - ETA: 1s - loss: 0.0234 - acc: 0.9929
43968/60000 [====================>.........] - ETA: 1s - loss: 0.0233 - acc: 0.9930
44608/60000 [=====================>........] - ETA: 1s - loss: 0.0234 - acc: 0.9929
45184/60000 [=====================>........] - ETA: 1s - loss: 0.0233 - acc: 0.9930
45888/60000 [=====================>........] - ETA: 1s - loss: 0.0231 - acc: 0.9930
46528/60000 [======================>.......] - ETA: 1s - loss: 0.0231 - acc: 0.9931
47168/60000 [======================>.......] - ETA: 1s - loss: 0.0231 - acc: 0.9930
47808/60000 [======================>.......] - ETA: 1s - loss: 0.0231 - acc: 0.9931
48448/60000 [=======================>......] - ETA: 0s - loss: 0.0231 - acc: 0.9930
49088/60000 [=======================>......] - ETA: 0s - loss: 0.0230 - acc: 0.9931
49728/60000 [=======================>......] - ETA: 0s - loss: 0.0230 - acc: 0.9930
50368/60000 [========================>.....] - ETA: 0s - loss: 0.0228 - acc: 0.9931
51008/60000 [========================>.....] - ETA: 0s - loss: 0.0228 - acc: 0.9931
51648/60000 [========================>.....] - ETA: 0s - loss: 0.0234 - acc: 0.9930
52288/60000 [=========================>....] - ETA: 0s - loss: 0.0232 - acc: 0.9930
52864/60000 [=========================>....] - ETA: 0s - loss: 0.0232 - acc: 0.9930
53504/60000 [=========================>....] - ETA: 0s - loss: 0.0232 - acc: 0.9930
54144/60000 [==========================>...] - ETA: 0s - loss: 0.0233 - acc: 0.9929
54848/60000 [==========================>...] - ETA: 0s - loss: 0.0233 - acc: 0.9929
55488/60000 [==========================>...] - ETA: 0s - loss: 0.0235 - acc: 0.9929
56128/60000 [===========================>..] - ETA: 0s - loss: 0.0233 - acc: 0.9929
56832/60000 [===========================>..] - ETA: 0s - loss: 0.0234 - acc: 0.9929
57472/60000 [===========================>..] - ETA: 0s - loss: 0.0234 - acc: 0.9929
58112/60000 [============================>.] - ETA: 0s - loss: 0.0233 - acc: 0.9929
58816/60000 [============================>.] - ETA: 0s - loss: 0.0233 - acc: 0.9929
59520/60000 [============================>.] - ETA: 0s - loss: 0.0234 - acc: 0.9929
60000/60000 [==============================] - 5s 82us/step - loss: 0.0233 - acc: 0.9929
Epoch 5/5
   64/60000 [..............................] - ETA: 6s - loss: 6.2760e-04 - acc: 1.0000
  704/60000 [..............................] - ETA: 4s - loss: 0.0160 - acc: 0.9929    
 1344/60000 [..............................] - ETA: 4s - loss: 0.0151 - acc: 0.9940
 1984/60000 [..............................] - ETA: 4s - loss: 0.0142 - acc: 0.9955
 2624/60000 [>.............................] - ETA: 4s - loss: 0.0124 - acc: 0.9962
 3200/60000 [>.............................] - ETA: 4s - loss: 0.0122 - acc: 0.9962
 3840/60000 [>.............................] - ETA: 4s - loss: 0.0143 - acc: 0.9961
 4480/60000 [=>............................] - ETA: 4s - loss: 0.0127 - acc: 0.9967
 5120/60000 [=>............................] - ETA: 4s - loss: 0.0131 - acc: 0.9965
 5696/60000 [=>............................] - ETA: 4s - loss: 0.0139 - acc: 0.9963
 6336/60000 [==>...........................] - ETA: 4s - loss: 0.0135 - acc: 0.9962
 7040/60000 [==>...........................] - ETA: 4s - loss: 0.0131 - acc: 0.9963
 7616/60000 [==>...........................] - ETA: 4s - loss: 0.0127 - acc: 0.9963
 8256/60000 [===>..........................] - ETA: 4s - loss: 0.0159 - acc: 0.9955
 8896/60000 [===>..........................] - ETA: 4s - loss: 0.0163 - acc: 0.9954
 9600/60000 [===>..........................] - ETA: 4s - loss: 0.0158 - acc: 0.9954
10240/60000 [====>.........................] - ETA: 4s - loss: 0.0162 - acc: 0.9950
10880/60000 [====>.........................] - ETA: 4s - loss: 0.0156 - acc: 0.9952
11520/60000 [====>.........................] - ETA: 3s - loss: 0.0159 - acc: 0.9951
12224/60000 [=====>........................] - ETA: 3s - loss: 0.0159 - acc: 0.9948
12864/60000 [=====>........................] - ETA: 3s - loss: 0.0155 - acc: 0.9949
13504/60000 [=====>........................] - ETA: 3s - loss: 0.0162 - acc: 0.9947
14144/60000 [======>.......................] - ETA: 3s - loss: 0.0157 - acc: 0.9948
14784/60000 [======>.......................] - ETA: 3s - loss: 0.0165 - acc: 0.9949
15424/60000 [======>.......................] - ETA: 3s - loss: 0.0166 - acc: 0.9947
16064/60000 [=======>......................] - ETA: 3s - loss: 0.0166 - acc: 0.9948
16832/60000 [=======>......................] - ETA: 3s - loss: 0.0166 - acc: 0.9948
17472/60000 [=======>......................] - ETA: 3s - loss: 0.0163 - acc: 0.9949
18048/60000 [========>.....................] - ETA: 3s - loss: 0.0164 - acc: 0.9948
18688/60000 [========>.....................] - ETA: 3s - loss: 0.0166 - acc: 0.9948
19328/60000 [========>.....................] - ETA: 3s - loss: 0.0169 - acc: 0.9947
20032/60000 [=========>....................] - ETA: 3s - loss: 0.0178 - acc: 0.9943
20672/60000 [=========>....................] - ETA: 3s - loss: 0.0176 - acc: 0.9943
21312/60000 [=========>....................] - ETA: 3s - loss: 0.0175 - acc: 0.9944
22016/60000 [==========>...................] - ETA: 3s - loss: 0.0181 - acc: 0.9941
22656/60000 [==========>...................] - ETA: 3s - loss: 0.0183 - acc: 0.9940
23360/60000 [==========>...................] - ETA: 2s - loss: 0.0183 - acc: 0.9940
24000/60000 [===========>..................] - ETA: 2s - loss: 0.0186 - acc: 0.9940
24640/60000 [===========>..................] - ETA: 2s - loss: 0.0185 - acc: 0.9939
25280/60000 [===========>..................] - ETA: 2s - loss: 0.0182 - acc: 0.9940
25920/60000 [===========>..................] - ETA: 2s - loss: 0.0178 - acc: 0.9941
26560/60000 [============>.................] - ETA: 2s - loss: 0.0175 - acc: 0.9943
27200/60000 [============>.................] - ETA: 2s - loss: 0.0177 - acc: 0.9943
27904/60000 [============>.................] - ETA: 2s - loss: 0.0177 - acc: 0.9943
28544/60000 [=============>................] - ETA: 2s - loss: 0.0179 - acc: 0.9942
29120/60000 [=============>................] - ETA: 2s - loss: 0.0179 - acc: 0.9942
29760/60000 [=============>................] - ETA: 2s - loss: 0.0177 - acc: 0.9942
30464/60000 [==============>...............] - ETA: 2s - loss: 0.0176 - acc: 0.9943
31040/60000 [==============>...............] - ETA: 2s - loss: 0.0174 - acc: 0.9943
31744/60000 [==============>...............] - ETA: 2s - loss: 0.0173 - acc: 0.9943
32384/60000 [===============>..............] - ETA: 2s - loss: 0.0174 - acc: 0.9943
33088/60000 [===============>..............] - ETA: 2s - loss: 0.0178 - acc: 0.9942
33728/60000 [===============>..............] - ETA: 2s - loss: 0.0178 - acc: 0.9942
34368/60000 [================>.............] - ETA: 2s - loss: 0.0178 - acc: 0.9942
35008/60000 [================>.............] - ETA: 2s - loss: 0.0176 - acc: 0.9942
35648/60000 [================>.............] - ETA: 1s - loss: 0.0174 - acc: 0.9943
36288/60000 [=================>............] - ETA: 1s - loss: 0.0173 - acc: 0.9943
36928/60000 [=================>............] - ETA: 1s - loss: 0.0173 - acc: 0.9943
37632/60000 [=================>............] - ETA: 1s - loss: 0.0172 - acc: 0.9943
38336/60000 [==================>...........] - ETA: 1s - loss: 0.0176 - acc: 0.9942
38976/60000 [==================>...........] - ETA: 1s - loss: 0.0175 - acc: 0.9942
39552/60000 [==================>...........] - ETA: 1s - loss: 0.0175 - acc: 0.9942
40192/60000 [===================>..........] - ETA: 1s - loss: 0.0174 - acc: 0.9943
40832/60000 [===================>..........] - ETA: 1s - loss: 0.0173 - acc: 0.9943
41408/60000 [===================>..........] - ETA: 1s - loss: 0.0173 - acc: 0.9943
41984/60000 [===================>..........] - ETA: 1s - loss: 0.0172 - acc: 0.9943
42624/60000 [====================>.........] - ETA: 1s - loss: 0.0172 - acc: 0.9942
43264/60000 [====================>.........] - ETA: 1s - loss: 0.0172 - acc: 0.9942
43904/60000 [====================>.........] - ETA: 1s - loss: 0.0174 - acc: 0.9942
44544/60000 [=====================>........] - ETA: 1s - loss: 0.0173 - acc: 0.9941
45184/60000 [=====================>........] - ETA: 1s - loss: 0.0180 - acc: 0.9941
45888/60000 [=====================>........] - ETA: 1s - loss: 0.0179 - acc: 0.9941
46464/60000 [======================>.......] - ETA: 1s - loss: 0.0179 - acc: 0.9941
47104/60000 [======================>.......] - ETA: 1s - loss: 0.0177 - acc: 0.9941
47744/60000 [======================>.......] - ETA: 1s - loss: 0.0177 - acc: 0.9942
48384/60000 [=======================>......] - ETA: 0s - loss: 0.0179 - acc: 0.9941
48960/60000 [=======================>......] - ETA: 0s - loss: 0.0178 - acc: 0.9941
49664/60000 [=======================>......] - ETA: 0s - loss: 0.0177 - acc: 0.9942
50304/60000 [========================>.....] - ETA: 0s - loss: 0.0177 - acc: 0.9942
50944/60000 [========================>.....] - ETA: 0s - loss: 0.0178 - acc: 0.9942
51648/60000 [========================>.....] - ETA: 0s - loss: 0.0179 - acc: 0.9942
52288/60000 [=========================>....] - ETA: 0s - loss: 0.0178 - acc: 0.9942
52928/60000 [=========================>....] - ETA: 0s - loss: 0.0179 - acc: 0.9942
53568/60000 [=========================>....] - ETA: 0s - loss: 0.0177 - acc: 0.9943
54208/60000 [==========================>...] - ETA: 0s - loss: 0.0176 - acc: 0.9943
54784/60000 [==========================>...] - ETA: 0s - loss: 0.0178 - acc: 0.9943
55424/60000 [==========================>...] - ETA: 0s - loss: 0.0178 - acc: 0.9943
56000/60000 [===========================>..] - ETA: 0s - loss: 0.0177 - acc: 0.9943
56640/60000 [===========================>..] - ETA: 0s - loss: 0.0176 - acc: 0.9944
57216/60000 [===========================>..] - ETA: 0s - loss: 0.0177 - acc: 0.9944
57792/60000 [===========================>..] - ETA: 0s - loss: 0.0178 - acc: 0.9944
58432/60000 [============================>.] - ETA: 0s - loss: 0.0180 - acc: 0.9943
59072/60000 [============================>.] - ETA: 0s - loss: 0.0182 - acc: 0.9943
59648/60000 [============================>.] - ETA: 0s - loss: 0.0182 - acc: 0.9944
60000/60000 [==============================] - 5s 82us/step - loss: 0.0184 - acc: 0.9943
   32/10000 [..............................] - ETA: 15s
 1056/10000 [==>...........................] - ETA: 0s 
 2048/10000 [=====>........................] - ETA: 0s
 3040/10000 [========>.....................] - ETA: 0s
 4032/10000 [===========>..................] - ETA: 0s
 5056/10000 [==============>...............] - ETA: 0s
 6048/10000 [=================>............] - ETA: 0s
 7040/10000 [====================>.........] - ETA: 0s
 8032/10000 [=======================>......] - ETA: 0s
 9088/10000 [==========================>...] - ETA: 0s
10000/10000 [==============================] - 1s 55us/step
Accuracy
Normal model 0.9905
Unbalanced model 0.9495
Comparison between weights:
K-S comparison (the distribution is similar when the K-S statistic is small and p > 0.05):
K-S=0.0106 p=0.031
normal: [   11   151   913  3936  9544 11161  7852  2702   528    66]
   bad: [   11    92   794  3969  9443 11182  7949  2804   557    55]
bins:   [-0.3850732  -0.310878   -0.2366828  -0.16248758 -0.08829238 -0.01409717
  0.06009804  0.13429324  0.20848846  0.28268367  0.35687888]
Comparison between biases:
K-S comparison (the distribution is similar when the K-S statistic is small and p > 0.05):
K-S=0.1718 p=0.274
normal: [ 1  4  3 11 12  9 11  7  4  2]
   bad: [ 3  6  7  8  6 10  6  6  5  1]
bins:   [ 3  6  7  8  6 10  6  6  5  1]
Process finished with exit code 0
```